### PR TITLE
fix(sdk): Support design-time builds in Feersum SDK

### DIFF
--- a/eng/UseLocalCompiler.props
+++ b/eng/UseLocalCompiler.props
@@ -1,5 +1,6 @@
 <Project>
-
+  <Import Project="$(MSBuildThisFileDirectory)../src/Feersum.Sdk/props/Feersum.Sdk.props" />
+  
   <PropertyGroup>
     <LanguageTargets Condition="'$(MSBuildProjectExtension)' == '.scmproj'">$(MSBuildThisFileDirectory)../src/Feersum.Sdk/targets/Feersum.Sdk.targets</LanguageTargets>
   </PropertyGroup>

--- a/eng/UseStage1Compiler.props
+++ b/eng/UseStage1Compiler.props
@@ -1,5 +1,7 @@
 <Project>
 
+  <Import Project="$(MSBuildThisFileDirectory)../src/Feersum.Sdk/props/Feersum.Sdk.props" />
+
   <PropertyGroup>
     <LanguageTargets Condition="'$(MSBuildProjectExtension)' == '.scmproj'">$(MSBuildThisFileDirectory)../src/Feersum.Sdk/targets/Feersum.Sdk.targets</LanguageTargets>
   </PropertyGroup>

--- a/src/Feersum.Sdk/Feersum.Sdk.proj
+++ b/src/Feersum.Sdk/Feersum.Sdk.proj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <None Include="sdk\**" PackagePath="sdk/" Pack="true" />
     <None Include="targets\**" PackagePath="targets/" Pack="true" />
+    <None Include="props\**" PackagePath="props/" Pack="true" />
   </ItemGroup>
 
   <!-- When restoring the compiler with `PackageReference` the target file wants

--- a/src/Feersum.Sdk/props/Feersum.Sdk.props
+++ b/src/Feersum.Sdk/props/Feersum.Sdk.props
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Declare our language support to .NET SDK / project system -->
+  <ItemGroup>
+    <ProjectCapability Include="AssemblyReferences" />
+    <ProjectCapability Include="DependenciesTree" />
+    <ProjectCapability Include="DotNetCore" />
+    <ProjectCapability Include="Managed" />
+    <ProjectCapability Include="PackageReferences" />
+    <ProjectCapability Include="ProjectReferences" />
+    <ProjectCapability Include="SdkStyle" />
+    <ProjectCapability Include="TargetFramework" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <DefaultLanguageSourceExtension>scm</DefaultLanguageSourceExtension>
+    <Language>Scheme</Language>
+    <TargetRuntime>Managed</TargetRuntime>
+    <DefaultProjectTypeGuid Condition=" '$(DefaultProjectTypeGuid)' == '' ">{B4FD8357-953D-49DE-A05E-DDBFD6E9489C}</DefaultProjectTypeGuid>
+  </PropertyGroup>
+
+  <!-- Disable bits of the .NET MSBuild SDK we don't want to use. -->
+  <PropertyGroup>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <!-- FIXME: PDB generation is controlled by build configuration. Stop
+        MSBuild from expecting PDB files if we are in release mode.
+        
+        Instead of this we should have a separate pair of `DebugType`, and
+        `PdbOut` parameters to control PDB generation in isolation.  -->
+    <DebugType Condition=" '$(Configuration)'!='Debug' ">None</DebugType>
+  </PropertyGroup>
+
+</Project>

--- a/src/Feersum.Sdk/sdk/Sdk.props
+++ b/src/Feersum.Sdk/sdk/Sdk.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <Import Project="$(MSBuildThisFileDirectory)..\props\Feersum.Sdk.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
     
 </Project>

--- a/src/Feersum.Sdk/targets/Feersum.Sdk.Core.targets
+++ b/src/Feersum.Sdk/targets/Feersum.Sdk.Core.targets
@@ -54,7 +54,7 @@
       <DotNetPath Condition=" '$(DotNetPath)' == '' ">dotnet</DotNetPath>
     </PropertyGroup>
 
-    <Error Condition="'$(DesignTimeBuild)' != 'true' and !Exists($(FeersumCompilerPath))" Text="Compiler build output is missing" />
+    <Error Condition="'$(DesignTimeBuild)' != 'true' and !Exists('$(FeersumCompilerPath)')" Text="Compiler build output is missing" />
 
     <PropertyGroup>
       <!-- References to the runtime's core library -->
@@ -71,10 +71,12 @@
       <BuildCommand>"$(DotNetPath)" "$(FeersumCompilerPath)" $(CoreLibReferences) $(LibReferences) $(ConfigParams) -o "@(IntermediateAssembly)" @(SchemeCompileItems->'"%(Identity)"', ' ')</BuildCommand>
     </PropertyGroup>
 
-    <!-- Skip actual compilation during design-time builds. Touch the output
-         so downstream targets that check for file existence don't fail. -->
+    <!-- Skip actual compilation during design-time builds. Touch a design-time
+         stub (not the real output) so the real assembly's timestamp is not
+         polluted; a subsequent normal build will therefore always re-run
+         CoreCompile and produce a genuine assembly. -->
     <Exec Condition="'$(DesignTimeBuild)' != 'true'" Command="$(BuildCommand)" EchoOff="true" />
-    <Touch Condition="'$(DesignTimeBuild)' == 'true'" Files="@(IntermediateAssembly)" AlwaysCreate="true" />
+    <Touch Condition="'$(DesignTimeBuild)' == 'true'" Files="$(IntermediateOutputPath)$(AssemblyName).designtime.dll" AlwaysCreate="true" />
 
   </Target>
 

--- a/src/Feersum.Sdk/targets/Feersum.Sdk.Core.targets
+++ b/src/Feersum.Sdk/targets/Feersum.Sdk.Core.targets
@@ -1,26 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Declare our language support to .NET SDK -->
-  <PropertyGroup>
-    <DefaultLanguageSourceExtension>scm</DefaultLanguageSourceExtension>
-    <Language>Scheme</Language>
-    <TargetRuntime>Managed</TargetRuntime>
-    <DefaultProjectTypeGuid Condition=" '$(DefaultProjectTypeGuid)' == '' ">{B4FD8357-953D-49DE-A05E-DDBFD6E9489C}</DefaultProjectTypeGuid>
-  </PropertyGroup>
-
-  <!-- Disable bits of the .NET MSBuild SDK we don't want to use. -->
-  <PropertyGroup>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-    <!-- FIXME: PDB generation is controlled by build configuration. Stop
-        MSBuild from expecting PDB files if we are in release mode.
-        
-        Instead of this we should have a separate pair of `DebugType`, and
-        `PdbOut` parameters to control PDB generation in isolation.  -->
-    <DebugType Condition=" '$(Configuration)'!='Debug' ">None</DebugType>
-  </PropertyGroup>
-
   <Import Project="$(MSBuildThisFileDirectory)Versions.props" Condition="Exists('$(MSBuildThisFileDirectory)Versions.props')" />
 
   <!-- Control the implicit package references used for the compiler and core.  -->
@@ -74,7 +54,7 @@
       <DotNetPath Condition=" '$(DotNetPath)' == '' ">dotnet</DotNetPath>
     </PropertyGroup>
 
-    <Error Condition="!Exists($(FeersumCompilerPath))" Text="Compiler build output is missing" />
+    <Error Condition="'$(DesignTimeBuild)' != 'true' and !Exists($(FeersumCompilerPath))" Text="Compiler build output is missing" />
 
     <PropertyGroup>
       <!-- References to the runtime's core library -->
@@ -91,7 +71,10 @@
       <BuildCommand>"$(DotNetPath)" "$(FeersumCompilerPath)" $(CoreLibReferences) $(LibReferences) $(ConfigParams) -o "@(IntermediateAssembly)" @(SchemeCompileItems->'"%(Identity)"', ' ')</BuildCommand>
     </PropertyGroup>
 
-    <Exec Command="$(BuildCommand)" EchoOff="true" />
+    <!-- Skip actual compilation during design-time builds. Touch the output
+         so downstream targets that check for file existence don't fail. -->
+    <Exec Condition="'$(DesignTimeBuild)' != 'true'" Command="$(BuildCommand)" EchoOff="true" />
+    <Touch Condition="'$(DesignTimeBuild)' == 'true'" Files="@(IntermediateAssembly)" AlwaysCreate="true" />
 
   </Target>
 


### PR DESCRIPTION
Move language properties and ProjectCapability declarations into a new Feersum.Sdk.props file, imported early from Sdk.props. This ensures IDE project systems (VS, C# Dev Kit) see capabilities as MSBuild items rather than a property string.

Guard CoreCompile's Exec and compiler-missing Error with DesignTimeBuild conditions so IDEs can evaluate .scmproj projects without running the full compiler. Touch a stub assembly during design-time builds to satisfy downstream existence checks.

Update eng/ local-dev props to import the new Feersum.Sdk.props so dogfood builds also get the capabilities.