### PR TITLE
Fixup Version Templating for SDK Template

### DIFF
--- a/src/Feersum.Templates/Feersum.Templates.proj
+++ b/src/Feersum.Templates/Feersum.Templates.proj
@@ -31,7 +31,7 @@
       <TfmSpecificPackageFile Include="$(BaseIntermediateOutputPath)%(TemplateInputs.FileName)%(TemplateInputs.Extension)" Pack="true" PackagePath="content/$([msbuild]::MakeRelative('$(MSBuildThisFileDirectory)templates', '$(MSBuildThisFileDirectory)%(TemplateInputs.RelativeDir)'))  " />
     </ItemGroup>
 
-    <WriteLinesToFile File="$(BaseIntermediateOutputPath)%(TemplateInputs.FileName)%(TemplateInputs.Extension)" Lines="$([System.IO.File]::ReadAllText('%(TemplateInputs.Identity)').Replace('Feersum.Sdk/0.2.1', 'Feersum.Sdk/$(Version)'))" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(BaseIntermediateOutputPath)%(TemplateInputs.FileName)%(TemplateInputs.Extension)" Lines="$([System.IO.File]::ReadAllText('%(TemplateInputs.Identity)').Replace('Feersum.Sdk/TEMPLATE_VERSION', 'Feersum.Sdk/$(Version)'))" Overwrite="true" WriteOnlyWhenDifferent="true" />
   </Target>
 
 </Project>

--- a/src/Feersum.Templates/templates/scm-classlib/FeersumLibrary.scmproj
+++ b/src/Feersum.Templates/templates/scm-classlib/FeersumLibrary.scmproj
@@ -1,4 +1,4 @@
-<Project Sdk="Feersum.Sdk/0.2.6">
+<Project Sdk="Feersum.Sdk/TEMPLATE_VERSION">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/src/Feersum.Templates/templates/scm-console/FeersumConsole.scmproj
+++ b/src/Feersum.Templates/templates/scm-console/FeersumConsole.scmproj
@@ -1,4 +1,4 @@
-<Project Sdk="Feersum.Sdk/0.2.6">
+<Project Sdk="Feersum.Sdk/TEMPLATE_VERSION">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
The version templating regressed as the version number was changed from the one recognised by the MSBuild to a later one. Fix the templating and use a hardcoded string which is clearly a template / placehodler so this doesn't get changed accidentally again.