### PR TITLE
[WIP] Symbol Table Abstraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/design-docs/06-file-collections-and-scope.md
+++ b/docs/design-docs/06-file-collections-and-scope.md
@@ -1,0 +1,396 @@
+# File Collections, Scope, and Symbol API
+
+This document revises and supersedes the compilation-model portions of
+[Workspace and Symbol API](./workspace-and-symbol-api/) in light of
+implementation changes made since that document was written. The symbol API
+design in the earlier document remains the authoritative source for `Scope.t`,
+`Symbol`, and library pickling; this document updates only the structural
+architecture and refines the bound-tree model.
+
+## Background
+
+### What Changed
+
+[Design doc 05](./workspace-and-symbol-api/) was written before three
+significant implementation changes landed on `feature/workspaces`:
+
+1. **`SourceRegistry` removed.** The mutable registry that assigned `DocId`
+   values and stored raw text has been deleted from `Text.fs`. There is no
+   longer a central store of source text inside the compiler.
+
+2. **`DocId` removed from the CST.** Individual green/red tree nodes no longer
+   carry a document identity. Source provenance is now held by the
+   `SyntaxRoot<'a>` wrapper that the parser returns, not by the tree itself.
+   This means a syntax tree is a fully portable, self-contained value — it can
+   be passed around, stored, cloned, and processed without any reference to a
+   registry.
+
+3. **`StxPos` is now compact.** Syntax positions store a `TextDocument` and a
+   raw `Firethorn.TextRange` rather than pre-resolved line/column pairs.
+   Resolving to human-readable `TextLocation` is deferred until a diagnostic is
+   actually emitted.
+
+The net effect of these three changes is that **syntax trees are isolated
+items**. A `SyntaxRoot<Program>` knows its source document and its tree; it
+needs nothing else to be a valid, complete input to the binder.
+
+The compiler-level `Workspace` proposed in doc 05 — a thin wrapper around
+`SourceRegistry` with a lazy parse cache — is therefore no longer needed or
+appropriate at the compiler layer. The `Workspace` concept now lives exclusively
+in the LSP layer, where it already exists as `WorkspaceAgent` in
+`Feersum.LanguageServer`.
+
+### Remaining Problems
+
+The architecture of `Scope` and `BoundSyntaxTree` is still largely as described
+in doc 05's "Current State" section:
+
+- `Scope = Map<string, StorageRef>` in `Environments.fs` is explicitly labelled
+  a shim and conflates syntax identity with storage location.
+- `BoundSyntaxTree` carries no symbol table: there is no record of which
+  identifiers are definitions, which are references, or what is exported.
+- The binder entry points (`bindProgram`, `bindScript`) accept `allLibs` as a
+  raw list threaded through every call, and return a `BoundSyntaxTree` with no
+  outward-facing scope. Chaining compilations for the REPL requires
+  re-compiling from scratch.
+- `Compilation.compile` in `Compiler.fs` is a monolithic function that
+  rebuilds all library signatures on every invocation.
+
+---
+
+## Design
+
+### Revised Architecture: Two Layers
+
+The three-layer model from doc 05 collapses to two layers now that the compiler
+no longer owns source text:
+
+```
++------------------------------------------------------+
+|  Compilation  (bind -> lower -> emit)                |
+|  - accepts Scope (input environment)                  |
+|  - returns BoundSyntaxTree + Scope (output env)       |
+|  - input is a FileCollection or single SyntaxRoot     |
++------------------------------------------------------+
+                        ^
+                        |  SyntaxRoot<'a>
+                        |
++------------------------------------------------------+
+|  Parse  (text -> SyntaxRoot)                          |
+|  - Parse.readProgram / readScript / readExpr1         |
+|  - returns SyntaxRoot<Program> / SyntaxRoot<Script>   |
+|  - no global state; caller owns the result            |
++------------------------------------------------------+
+```
+
+The LSP layer sits **beside** this pipeline, not inside it:
+
+```
++------------------------------------------+
+|  WorkspaceAgent  (LSP actor)             |
+|  - stores document text + versions       |
+|  - calls Parse.readProgram on demand     |
+|  - feeds SyntaxRoot values to binder     |
++------------------------------------------+
+```
+
+`WorkspaceAgent` (already in `Feersum.LanguageServer/Workspace.fs`) is the
+correct and complete home for LSP document tracking. No workspace type belongs
+in `Feersum.CompilerServices`.
+
+---
+
+### Layer 1: File Collections
+
+A **file collection** is the natural input type for multi-file compilations. It
+is simply a list of already-parsed `SyntaxRoot<Program>` values. No wrapper
+type is required; the list itself is the collection.
+
+```fsharp
+/// A parsed program file ready for the binder.
+type FileCollection = SyntaxRoot<Program> list
+```
+
+Helper functions in the `Parse` module or a thin `FileCollection` module can
+construct these from paths on disk:
+
+```fsharp
+module FileCollection =
+
+    /// Parse each path, accumulating diagnostics. Returns a ParseResult whose
+    /// Root is the list of successfully parsed roots.
+    val ofPaths : string list -> ParseResult<FileCollection>
+
+    /// Build a collection directly from already-parsed roots (tests, LSP).
+    val ofRoots : SyntaxRoot<Program> list -> FileCollection
+```
+
+`compileFiles` in `Compiler.fs` is then reduced to:
+
+```fsharp
+let compileFiles options output paths =
+    let result = FileCollection.ofPaths paths
+    if hasErrors result.Diagnostics then result.Diagnostics
+    else compile options output (CompileInput.Program result.Root)
+```
+
+---
+
+### Layer 2: Scope as the Environment Type
+
+`Scope` replaces `Map<string, StorageRef>` (the shim in `Environments.fs`) as
+the canonical environment flowing into and out of the binder.
+
+The `Scope` type and `Symbol` vocabulary are defined in detail in
+[Workspace and Symbol API](./workspace-and-symbol-api/). The key addition here
+is making `Scope` the **explicit output** of every binder entry point, not just
+an internal detail.
+
+#### Binder Entry Points
+
+```fsharp
+module Binder =
+
+    /// Bind a script. Returns the bound tree and the updated scope containing
+    /// any top-level definitions made during binding. The output scope is the
+    /// correct input scope for the next REPL step.
+    val bindScript :
+        scope: Scope
+        -> input: SyntaxRoot<ScriptProgram>
+        -> BoundSyntaxTree * Scope
+
+    /// Bind a program (one or more library files). Returns the bound tree and
+    /// the scope of exported names. The output scope can be fed into
+    /// LibraryRegistry.add to make the library importable.
+    val bindProgram :
+        scope: Scope
+        -> inputs: FileCollection
+        -> BoundSyntaxTree * Scope
+```
+
+The `allLibs: LibrarySignature<StorageRef> list` argument disappears: import
+resolution is driven by the `LibraryRegistry` embedded in the `Scope` (as
+described in doc 05). The binder calls `Scope.importLibrary` when it encounters
+an `(import ...)` form.
+
+#### REPL Chaining
+
+With `Scope` as an explicit output the REPL loop becomes a straightforward fold:
+
+```fsharp
+let runRepl () =
+    let mutable scope = Compiler.baseScope ()  // builtins pre-opened
+
+    while true do
+        let input = readLine ()                     // SyntaxRoot<ScriptProgram>
+        let tree, scope' = Binder.bindScript scope input
+        eval tree                                   // lower -> emit -> invoke
+        scope <- scope'
+```
+
+No `Compilation.derive`, no re-seeding from scratch. The scope accumulates
+incrementally, carrying all top-level definitions forward between inputs.
+
+#### Export / Import Model
+
+For library compilations the output `Scope` from `bindProgram` contains all
+names defined within the library. The caller applies export filtering before
+registering the library:
+
+```fsharp
+// Inside the compiler pipeline, after bindProgram:
+let exportedScope = Scope.filterToExports exportSet outputScope
+let libScope = LibraryScope.ofScope libName exportedScope
+let registry' = LibraryRegistry.add libScope registry
+```
+
+This separates the binder (which sees every definition) from the library
+registry (which sees only the public API).
+
+---
+
+### Layer 3: Bound Syntax Tree Symbol Model
+
+The `BoundSyntaxTree` currently carries only what is needed to drive code
+emission (`BoundBody`, `MangledName`, `Diagnostics`). For IDE features — hover,
+go-to-definition, find-all-references, rename — the bound tree must also carry
+a **symbol table** that records every definition and reference in the file.
+
+#### Core Types
+
+```fsharp
+/// Stable identity for a single binding introduction.
+/// Two definitions of the same name at different points get different ids.
+/// This is distinct from `Ident`, which lives in the syntax layer; a
+/// `DefinitionId` lives in the semantic layer.
+[<Struct>]
+type DefinitionId = private DefinitionId of int
+
+/// The kind of a definition.
+type DefinitionKind =
+    | TopLevel     // (define name ...)  at program / library scope
+    | Local        // let / letrec / letrec* binding
+    | Formal       // lambda formal parameter
+    | Imported     // name introduced by (import ...)
+    | SyntaxDef    // (define-syntax ...)
+
+/// A single name introduction in the bound tree.
+type Definition =
+    { Id       : DefinitionId
+      Name     : string
+      Kind     : DefinitionKind
+      Storage  : StorageRef
+      Location : TextLocation }
+
+/// A use of a previously introduced name.
+type Reference =
+    { Target   : DefinitionId
+      Location : TextLocation }
+
+/// The symbol table for a single bound compilation unit.
+type SymbolTable =
+    { /// All definitions introduced by this compilation unit,
+      /// in source order.
+      Definitions : Definition list
+
+      /// All resolved name references within this compilation unit.
+      References  : Reference list
+
+      /// Names exported by this unit (for library compilations).
+      /// Maps the exported string name to the definition that backs it.
+      Exports     : Map<string, DefinitionId>
+
+      /// Names imported into this unit, keyed by the local string name.
+      /// The StorageRef matches the one in the originating library scope.
+      Imports     : Map<string, StorageRef> }
+```
+
+#### Updated BoundSyntaxTree
+
+```fsharp
+type BoundSyntaxTree =
+    { Root        : BoundBody
+      MangledName : string
+      Diagnostics : Diagnostic list
+      /// Present only when the binder ran in 'rich' mode (e.g. for the LSP).
+      /// Absent in fast-compile mode to avoid the allocation overhead.
+      Symbols     : SymbolTable option }
+```
+
+The `Symbols` field is `None` by default. A separate entry point (or a flag on
+the scope/options) selects rich mode:
+
+```fsharp
+module Binder =
+
+    /// Fast path — no symbol table. Used by the CLI compiler and REPL eval.
+    val bindScript : Scope -> SyntaxRoot<ScriptProgram> -> BoundSyntaxTree * Scope
+
+    /// Rich path — symbol table populated. Used by the LSP for hover,
+    /// go-to-definition, and find-references.
+    val bindScriptRich : Scope -> SyntaxRoot<ScriptProgram> -> BoundSyntaxTree * Scope
+```
+
+The rich and fast paths share the same internal recursive traversal; the rich
+path threads a mutable `SymbolTableBuilder` alongside the binder state and
+freezes it into `SymbolTable` before returning.
+
+#### Interaction with Scope
+
+The `SymbolTable` and `Scope` are complementary:
+
+- `Scope` is the **live environment** — what names are visible right now and
+  where they live in storage. It flows between compilation steps.
+- `SymbolTable` is the **historical record** — what was defined and referenced
+  in a given file, and at what location. It is attached to the `BoundSyntaxTree`
+  and can be queried by the LSP after binding is complete.
+
+A definition recorded in `SymbolTable.Definitions` will have the same
+`StorageRef` as the binding in the output `Scope`. This allows the LSP to
+cross-reference: given a `Reference.Target : DefinitionId` and the
+`SymbolTable`, find the `StorageRef`; then look up the `StorageRef` in the
+`Scope` to determine if the definition is still live (relevant for REPL
+incremental sessions).
+
+---
+
+### LSP Workspace Integration
+
+`WorkspaceAgent` in `Feersum.LanguageServer` already correctly models the LSP
+layer: it tracks document text and versions, accepts open/change/close messages,
+and provides snapshots on demand. No changes to its structure are required.
+
+The `CompilationManager` in `Feersum.LanguageServer` should evolve to:
+
+1. Receive document snapshots from `WorkspaceAgent`.
+2. Call `Parse.readProgram` to obtain `SyntaxRoot<Program>` values.
+3. Call `Binder.bindScriptRich` (or `bindProgramRich`) with the current scope.
+4. Store the resulting `BoundSyntaxTree` (with its `SymbolTable`) for LSP
+   query handlers (hover, go-to-definition, semantic tokens).
+5. Forward updated `Scope` values for the next incremental compilation.
+
+The `CompilationManager` is the correct place to cache `SyntaxRoot` values
+between document versions (to avoid re-parsing unchanged files). This parse
+cache belongs at the LSP layer, not in the compiler core.
+
+---
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `src/Feersum.CompilerServices/Binding/Scope.fs` | **New.** `Scope` (opaque), `Symbol`, `LibraryRegistry`. See doc 05 for detail. |
+| `src/Feersum.CompilerServices/Binding/Environments.fs` | Remove shim `type Scope = Map<...>`; eventually deleted. |
+| `src/Feersum.CompilerServices/Binding/BoundTree.fs` | Add `DefinitionId`, `DefinitionKind`, `Definition`, `Reference`, `SymbolTable`. Add `Symbols` field to `BoundSyntaxTree`. |
+| `src/Feersum.CompilerServices/Binding/Binder.fs` | Change entry points to accept and return `Scope`. Add `bindScriptRich` / `bindProgramRich` variants. Remove `allLibs` argument (drives from `Scope`). |
+| `src/Feersum.CompilerServices/Compile/Compiler.fs` | Simplify `compile` to use `Scope`-threaded binder. Add `FileCollection` helpers. Remove `Workspace` references from doc 05 plan. |
+| `src/Feersum.CompilerServices/Compile/Builtins.fs` | Migrate to produce `LibraryScope` values for registry; remove `loadCoreSignatures` after registry wired in. |
+| `src/Feersum/Repl.fs` | Use `Scope` chaining instead of recompiling from scratch. |
+| `src/Feersum.LanguageServer/CompilationManager.fs` | Evolve to use `bindScriptRich`, store `SymbolTable`, provide LSP query API. |
+| `src/Feersum.LanguageServer/Workspace.fs` | No structural change; this is already the correct LSP actor model. |
+
+Files from doc 05's table that are **no longer needed**:
+
+| File | Reason |
+|------|--------|
+| `src/Feersum.CompilerServices/Workspace.fs` | Not created; `SourceRegistry` gone, parse cache belongs in LSP layer. |
+| `src/Feersum.CompilerServices/Compilation.fs` | Not created; `Compilation` type superseded by plain `Scope` threading. |
+
+---
+
+## Open Questions
+
+1. **`SymbolTableBuilder` concurrency model.** The rich binder path must
+   accumulate definition and reference records while performing a recursive
+   descent. A mutable `ResizeArray`-backed builder is simplest and avoids
+   repeated list consing; an immutable accumulator is safer. Preferred
+   direction: mutable builder, frozen to an immutable `SymbolTable` before the
+   binder returns.
+
+2. **`DefinitionId` lifetime.** Should `DefinitionId` values be stable across
+   re-parses of the same file (useful for the LSP to correlate a reference
+   across incremental compilations)? Content-addressing (e.g. a hash of name +
+   location) would give stability at the cost of collision risk. Preferred
+   direction: fresh monotonic integer per binding pass; the LSP re-queries on
+   each re-bind. Stable IDs can be introduced later if needed.
+
+3. **Scope output from `bindScript` for libraries.** `bindProgram` has a clear
+   distinction between the internal scope (all definitions) and the exported
+   scope (public API). For scripts this distinction does not exist — all
+   top-level defines are implicitly public. Should `bindScript` return the full
+   scope or should there be an explicit export step? Preferred direction: return
+   the full scope; the REPL and any script-level tooling can filter as needed.
+
+4. **`FileCollection` as a type alias vs. a new module.** Naming the list
+   `FileCollection = SyntaxRoot<Program> list` and giving it a small module
+   adds a convenient parse-from-paths helper but introduces an extra concept.
+   Preferred direction: introduce the module to keep `compileFiles` clean, but
+   keep the underlying representation as a plain list so callers never have to
+   unwrap it.
+
+5. **Interaction with library pickling.** When a library's `BoundSyntaxTree` is
+   emitted to a `.dll`, the `SymbolTable.Exports` should feed the `CompiledScope`
+   serialisation described in doc 05. The precise mapping (`DefinitionId` ->
+   `StableIdent`) is deferred to the pickling phase. Preferred direction:
+   `Emit.fs` walks `SymbolTable.Exports` when `OutputType = Lib` to build the
+   `CompiledScope`; no other file needs to know about pickling.

--- a/docs/design-docs/README.md
+++ b/docs/design-docs/README.md
@@ -7,3 +7,4 @@ accurate, or even useful.
  * [Syntax Trees](./syntax-trees/)
  * [Syntactic Closures Expansion and Binding](./syntactic-closures-expander/)
  * [Workspace and Symbol API](./workspace-and-symbol-api/)
+ * [File Collections, Scope, and Symbol API](./file-collections-and-scope/)

--- a/src/Feersum.CompilerServices/Binding/Binder.fs
+++ b/src/Feersum.CompilerServices/Binding/Binder.fs
@@ -109,6 +109,11 @@ module private ResolutionEnv =
         | active :: tail -> S(Map.add ident var active :: tail)
         | _ -> ice "ResolutionEnvironment has no active scope"
 
+    /// Extract the outermost (global) scope as a flat map.
+    /// After binding a program root all balanced push/pop pairs have cancelled
+    /// out, leaving a single scope containing only the top-level definitions.
+    let globalScope (S scopes) : Map<Ident, StorageRef> = List.last scopes
+
 /// Binder Frame Context
 ///
 /// A frame context represents the state of the binder as it processes a
@@ -253,8 +258,7 @@ module private Impl =
         name |> Seq.map mangleNamePart |> String.concat "::"
 
     // Get the Syntax Location for a Given Syntax Node
-    let private getSyntaxLocation (_ctx: BinderCtx) (stx: Stx) : TextLocation =
-        stx.Pos.Location
+    let private getSyntaxLocation (_ctx: BinderCtx) (stx: Stx) : TextLocation = stx.Pos.Location
 
 
     /// Parse a Formals List Pattern
@@ -504,7 +508,9 @@ module private Impl =
                     match expanded with
                     | Ok newForm -> bindInContext ctx stxEnv newForm
                     | Result.Error err ->
-                        err |> ctx.BinderCtx.Diagnostics.Emit MacroDiagnostics.macroExpansionError loc.Location
+                        err
+                        |> ctx.BinderCtx.Diagnostics.Emit MacroDiagnostics.macroExpansionError loc.Location
+
                         BoundExpr.Error, stxEnv
                 | None ->
                     $"Macro '{name}' is not defined in the current context"
@@ -1000,16 +1006,19 @@ module private Impl =
 
     /// Bind a Program Root
     ///
-    /// Walks the list of items and binds each one as a top level item
-    let bindProgramRoot (ctx: FrameCtx) (stxEnv: StxEnvironment) (stxs: Stx list) : BoundBody =
+    /// Walks the list of items and binds each one as a top level item.
+    /// Returns the bound body and the final syntax environment so the caller
+    /// can reconstruct the output `Scope`.
+    let bindProgramRoot (ctx: FrameCtx) (stxEnv: StxEnvironment) (stxs: Stx list) : BoundBody * StxEnvironment =
         let stxs, stxEnv = bindImports ctx stxEnv stxs
 
-        let body = bindSeq ctx stxEnv stxs |> fst
+        let body, stxEnv = bindSeq ctx stxEnv stxs
 
         { Body = body
           Locals = ctx.LocalCount
           Captures = []
-          EnvMappings = None }
+          EnvMappings = None },
+        stxEnv
 
 
 /// Public Binder API
@@ -1020,64 +1029,52 @@ module private Impl =
 /// `Lower` and `Emit`.
 module Binder =
 
-    /// Bind a List of Syntax Nodes in a Given Scope
+    /// Bind a list of syntax nodes using the given scope.
     ///
-    /// This is the main entry point for the binder. It takes a list of syntax
-    /// nodes representing the program to be bound, along with a source registry
-    /// and a scope for name resolution, and produces a `BoundSyntaxTree` which
-    /// contains the bound syntax tree along with diagnostics and a mangled name.
-    let private bindStx
-        (ctx: BinderCtx)
-        (stxEnv: StxEnvironment)
-        (scope: Map<Ident, StorageRef>)
-        (stx: Stx list)
-        : BoundSyntaxTree =
+    /// Returns the bound tree and an output scope that reflects all top-level
+    /// definitions introduced during binding. The output scope is the correct
+    /// input for the next compilation step (e.g. the next REPL line).
+    let private bindStx (inputScope: Scope) (ctx: BinderCtx) (stx: Stx list) : BoundSyntaxTree * Scope =
         let name = "LispProgram"
-        let rootFrame = FrameCtx.createGlobal ctx name scope
+        let rootFrame = FrameCtx.createGlobal ctx name inputScope.Bindings
 
-        let bound = bindProgramRoot rootFrame stxEnv stx
+        let bound, outputStxEnv = bindProgramRoot rootFrame inputScope.StxEnv stx
+
+        let outputScope =
+            { inputScope with
+                StxEnv = outputStxEnv
+                Bindings = ResolutionEnv.globalScope rootFrame.Env
+                Macros = ctx.Macros }
 
         { Root = bound
           MangledName = name
-          Diagnostics = ctx.Diagnostics.Take }
+          Diagnostics = ctx.Diagnostics.Take },
+        outputScope
 
 
-    /// Bind a List of Compilation Units in a Given Scope
+    /// Bind a collection of program files in the given scope.
     ///
-    /// Takes a list of dcocument and expression pairs and binds them in the
-    /// given scope.
-    let bindProgram
-        (stxEnv: StxEnvironment)
-        (scope: Map<Ident, StorageRef>)
-        (libs: seq<LibrarySignature<StorageRef>>)
-        (macros: Map<Ident, SyntaxTransformer>)
-        (units: SyntaxRoot<Program> list)
-        : BoundSyntaxTree =
-        let ctx = Binderctx.create (List.ofSeq libs) macros
+    /// Returns the bound tree and the output scope containing all top-level
+    /// definitions introduced across all files.
+    let bindProgram (scope: Scope) (units: SyntaxRoot<Program> list) : BoundSyntaxTree * Scope =
+        let ctx = Binderctx.create scope.Libs scope.Macros
 
         let toBind =
             units
             |> Seq.collect (fun unit -> unit.Item.Body |> Seq.map (Stx.ofExpr unit.Document ctx.Diagnostics))
 
-        bindStx ctx stxEnv scope (List.ofSeq toBind)
+        bindStx scope ctx (List.ofSeq toBind)
 
-    /// Bind a Single Script in a Given Scope
+    /// Bind a single script in the given scope.
     ///
-    /// Takes a single script program and binds it in the given scope. This is
-    /// used for the REPL and for single-file scripts, where we don't have a
-    /// sequence of compilation units but just a single script body to bind.
-    let bindScript
-        (stxEnv: StxEnvironment)
-        (scope: Map<Ident, StorageRef>)
-        (libs: seq<LibrarySignature<StorageRef>>)
-        (macros: Map<Ident, SyntaxTransformer>)
-        (script: SyntaxRoot<ScriptProgram>)
-        : BoundSyntaxTree =
-        let ctx = Binderctx.create (List.ofSeq libs) macros
+    /// Returns the bound tree and the output scope. The output scope is the
+    /// correct input for the next REPL step.
+    let bindScript (scope: Scope) (script: SyntaxRoot<ScriptProgram>) : BoundSyntaxTree * Scope =
+        let ctx = Binderctx.create scope.Libs scope.Macros
 
         let toBind =
             script.Item.Body
-            |> Option.map (Stx.ofExpr script.Document ctx.Diagnostics) // FIXME remove once we remove docId
+            |> Option.map (Stx.ofExpr script.Document ctx.Diagnostics)
             |> Option.toList
 
-        bindStx ctx stxEnv scope toBind
+        bindStx scope ctx toBind

--- a/src/Feersum.CompilerServices/Binding/Binder.fs
+++ b/src/Feersum.CompilerServices/Binding/Binder.fs
@@ -1035,7 +1035,7 @@ module Binder =
     /// definitions introduced during binding. The output scope is the correct
     /// input for the next compilation step (e.g. the next REPL line).
     let private bindStx (inputScope: Scope) (ctx: BinderCtx) (stx: Stx list) : BoundSyntaxTree * Scope =
-        let name = "LispProgram"
+        let name = inputScope.ProgramName
         let rootFrame = FrameCtx.createGlobal ctx name inputScope.Bindings
 
         let bound, outputStxEnv = bindProgramRoot rootFrame inputScope.StxEnv stx

--- a/src/Feersum.CompilerServices/Binding/Environments.fs
+++ b/src/Feersum.CompilerServices/Binding/Environments.fs
@@ -1,58 +1,52 @@
 namespace Feersum.CompilerServices.Binding
 
-open Feersum.CompilerServices.Binding
 open Feersum.CompilerServices.Binding.Libraries
 
-/// Shim type until proper scope is defined
-type Scope = Map<string, StorageRef>
+/// The compilation scope.
+///
+/// Bundles all environment pieces needed by the binder for a single
+/// compilation pass: the syntax environment (macros and variable bindings),
+/// the storage bindings for each resolved identifier, the available library
+/// signatures for import resolution, and the registered macro transformers.
+[<NoComparison; NoEquality>]
+type Scope =
+    { StxEnv: StxEnvironment
+      Bindings: Map<Ident, StorageRef>
+      Libs: LibrarySignature<StorageRef> list
+      Macros: Map<Ident, SyntaxTransformer> }
+
+module Scope =
+
+    /// The empty scope with no bindings, libraries, or macros.
+    let empty: Scope =
+        { StxEnv = Map.empty
+          Bindings = Map.empty
+          Libs = []
+          Macros = Map.empty }
+
+    /// Build a scope from a sequence of library signatures.
+    ///
+    /// Each exported name gets a fresh `Ident` in the syntax environment and
+    /// its `StorageRef` in the binding environment. The libraries are retained
+    /// so the binder can resolve subsequent `(import ...)` forms.
+    let ofLibraries (libs: seq<LibrarySignature<StorageRef>>) : Scope =
+        let stxEnv, bindings =
+            libs
+            |> Seq.collect (fun l -> l.Exports)
+            |> Seq.fold
+                (fun (stx, env) (name, storage) ->
+                    let id = Ident.fresh ()
+                    Map.add name (StxBinding.Variable id) stx, Map.add id storage env)
+                (Map.empty, Map.empty)
+
+        { StxEnv = stxEnv
+          Bindings = bindings
+          Libs = List.ofSeq libs
+          Macros = Map.empty }
 
 /// Creates initial binding environments for the expander.
-///
-/// FIXME: This module contains an odd mix of environment utitlities, syntax environment definitions and binding
-///        environments. Really this all needs cleaning up as part of the 'Symbols API' refactor.
 module Environments =
 
-    /// Create a preloaded scope from a sequence of library signatures.
-    /// Returns a Map<string, StorageRef> containing all exported names from the libraries.
-    let fromLibraries (libs: seq<LibrarySignature<StorageRef>>) : Scope =
-        libs |> Seq.collect (fun lib -> lib.Exports) |> Map.ofSeq
-
-    /// The empty preloaded scope.
-    let empty: Scope = Map.empty
-
-    /// The empty initial scope. Special forms are not stored in the scope;
+    /// The empty initial syntax environment. Special forms are not stored here;
     /// they are recognised by name in `resolveHead` via `tryResolveSpecial`.
-    /// Callers extend this with macro and variable bindings before expansion.
     let emptyStx: StxEnvironment = Map.empty
-
-    /// Break open a Scope into Constituent Parts
-    ///
-    /// Internally a scope contains a both a mapping from names to their syntax
-    /// binding, and a mapping from variable identifiers to their assigned
-    /// storage locations.  This Function walks the scope and produces these two
-    /// separate maps.
-    let intoParts (scope: Scope) : StxEnvironment * Map<Ident, StorageRef> =
-        scope
-        |> Map.fold
-            (fun (stx, env) key value ->
-                let id = Ident.fresh ()
-                (Map.add key (StxBinding.Variable(id)) stx, Map.add id value env))
-            (Map.empty, Map.empty)
-
-    /// Reconstruct a Scope from its Constituent Parts
-    ///
-    /// This is the inverse of `intoParts`. It takes a syntax environment and a
-    /// variable environment and produces a Scope. This is a lossy operation.
-    /// The returned `Scope` contains only syntax bindings which are live in
-    /// the given `env`. Other bindings will be silently dropped.
-    let fromParts (stx: StxEnvironment, env: Map<Ident, StorageRef>) : Scope =
-        stx
-        |> Map.fold
-            (fun scope key binding ->
-                match binding with
-                | StxBinding.Variable id ->
-                    match env.TryFind id with
-                    | Some value -> Map.add key value scope
-                    | None -> scope
-                | _ -> scope)
-            Map.empty

--- a/src/Feersum.CompilerServices/Binding/Environments.fs
+++ b/src/Feersum.CompilerServices/Binding/Environments.fs
@@ -13,7 +13,8 @@ type Scope =
     { StxEnv: StxEnvironment
       Bindings: Map<Ident, StorageRef>
       Libs: LibrarySignature<StorageRef> list
-      Macros: Map<Ident, SyntaxTransformer> }
+      Macros: Map<Ident, SyntaxTransformer>
+      ProgramName: string }
 
 module Scope =
 
@@ -22,7 +23,8 @@ module Scope =
         { StxEnv = Map.empty
           Bindings = Map.empty
           Libs = []
-          Macros = Map.empty }
+          Macros = Map.empty
+          ProgramName = "LispProgram" }
 
     /// Build a scope from a sequence of library signatures.
     ///
@@ -42,7 +44,8 @@ module Scope =
         { StxEnv = stxEnv
           Bindings = bindings
           Libs = List.ofSeq libs
-          Macros = Map.empty }
+          Macros = Map.empty
+          ProgramName = "LispProgram" }
 
 /// Creates initial binding environments for the expander.
 module Environments =

--- a/src/Feersum.CompilerServices/Binding/Libraries.fs
+++ b/src/Feersum.CompilerServices/Binding/Libraries.fs
@@ -168,7 +168,10 @@ module private Utils =
             imports |> List.map (parseImportSet diags) |> LibraryDeclaration.Import
         | StxList(Stx.Id("begin", _) :: body, _, _, _) -> LibraryDeclaration.Begin body
         | StxList(Stx.Id(kw, _) :: _, _, loc, _) ->
-            diags.Emit LibraryDiagnostics.malformedLibraryDecl loc.Location (sprintf "Unrecognised library declaration %s" kw)
+            diags.Emit
+                LibraryDiagnostics.malformedLibraryDecl
+                loc.Location
+                (sprintf "Unrecognised library declaration %s" kw)
 
             LibraryDeclaration.Error
         | other ->

--- a/src/Feersum.CompilerServices/Binding/Macros.fs
+++ b/src/Feersum.CompilerServices/Binding/Macros.fs
@@ -372,7 +372,11 @@ module MacroParse =
             let template = parseTemplate patternCtx patternScope 0 defScope tmpl
             (pattern, template)
         | _ ->
-            diags.Emit MacroDiagnostics.invalidMacro stx.Pos.Location "each syntax-rules rule must be (pattern template)"
+            diags.Emit
+                MacroDiagnostics.invalidMacro
+                stx.Pos.Location
+                "each syntax-rules rule must be (pattern template)"
+
             (MacroPattern.Underscore, MacroTemplate.Quoted stx)
 
     /// Parse a list of `(pattern template)` rules from the body of a `syntax-rules` form.
@@ -408,7 +412,11 @@ module MacroParse =
         | StxList(StxId("syntax-rules", _, _) :: lits :: rules, _, _, maybeDefEnv) ->
             parseBody "..." lits rules maybeDefEnv |> Some
         | _ ->
-            diags.Emit MacroDiagnostics.invalidMacro syntaxRulesSyn.Pos.Location "expected (syntax-rules (literals...) rules...)"
+            diags.Emit
+                MacroDiagnostics.invalidMacro
+                syntaxRulesSyn.Pos.Location
+                "expected (syntax-rules (literals...) rules...)"
+
             None
 
 /// Parse `(syntax-rules ...)` forms into `SyntaxTransformer` values.

--- a/src/Feersum.CompilerServices/Binding/Stx.fs
+++ b/src/Feersum.CompilerServices/Binding/Stx.fs
@@ -66,9 +66,7 @@ type StxPos =
 module StxPos =
     /// Sentinel value for compiler-synthesised nodes that have no source origin.
     let missing =
-        { Doc =
-            { Path = "missing"
-              LineStarts = [] }
+        { Doc = { Path = "missing"; LineStarts = [] }
           Range = Unchecked.defaultof<Firethorn.TextRange> }
 
 

--- a/src/Feersum.CompilerServices/Binding/Stx.fs
+++ b/src/Feersum.CompilerServices/Binding/Stx.fs
@@ -67,8 +67,7 @@ module StxPos =
     /// Sentinel value for compiler-synthesised nodes that have no source origin.
     let missing =
         { Doc =
-            { Id = DocId.Synthetic
-              Path = "missing"
+            { Path = "missing"
               LineStarts = [] }
           Range = Unchecked.defaultof<Firethorn.TextRange> }
 

--- a/src/Feersum.CompilerServices/Binding/Stx.fs
+++ b/src/Feersum.CompilerServices/Binding/Stx.fs
@@ -66,7 +66,10 @@ type StxPos =
 module StxPos =
     /// Sentinel value for compiler-synthesised nodes that have no source origin.
     let missing =
-        { Doc = { Id = DocId.Synthetic; Path = "missing"; LineStarts = [] }
+        { Doc =
+            { Id = DocId.Synthetic
+              Path = "missing"
+              LineStarts = [] }
           Range = Unchecked.defaultof<Firethorn.TextRange> }
 
 

--- a/src/Feersum.CompilerServices/Compile/Compiler.fs
+++ b/src/Feersum.CompilerServices/Compile/Compiler.fs
@@ -37,6 +37,26 @@ type Compilation =
         RefTypes: TypeDefinition list
     }
 
+/// The result of emitting a `Compilation`. Carries everything `createDerived`
+/// needs to chain the next REPL step: the output scope, accumulated extern
+/// types (prior steps included), and step index for unique type naming.
+[<NoComparison; NoEquality>]
+type CompilationOutput =
+    {
+        Diagnostics: Diagnostic list
+        EmittedAssemblyName: AssemblyNameDefinition option
+        OutputScope: Scope
+        Options: CompilationOptions
+        Target: TargetInfo
+        /// Accumulated extern TypeDefinitions: original references plus every
+        /// type emitted by prior REPL steps. Passed as `externTys` to Emit.emit
+        /// in the next step so previous globals are reachable as extern fields.
+        RefTypes: TypeDefinition list
+        /// Monotonically increasing step counter. Incremented by `createDerived`
+        /// to produce a unique `ProgramName` for each REPL compilation.
+        StepIndex: int
+    }
+
 module Compilation =
 
     // -- Helpers --------------------------------------------------------------
@@ -99,14 +119,17 @@ module Compilation =
           Target = target
           RefTypes = refTys }
 
-    /// Bind and lower, deriving the scope from a previous compilation.
+    /// Bind and lower, deriving the scope from a previous emit output.
     ///
     /// Inherits `Target`, `RefTypes`, and `Options` from `previous` (reference
-    /// loading is skipped). Uses `previous.OutputScope` as the input scope so
-    /// all top-level definitions from prior steps remain visible — the correct
-    /// entry point for REPL chaining.
-    let createDerived previous input =
-        let lowered, outputScope = bindAndLower previous.OutputScope input
+    /// loading is skipped). Uses `previous.OutputScope` as the input scope,
+    /// with an incremented `ProgramName` so each REPL step emits a unique type.
+    let createDerived (previous: CompilationOutput) input =
+        let nextScope =
+            { previous.OutputScope with
+                ProgramName = sprintf "LispProgram_%d" (previous.StepIndex + 1) }
+
+        let lowered, outputScope = bindAndLower nextScope input
 
         { BoundTree = lowered
           OutputScope = outputScope
@@ -117,23 +140,26 @@ module Compilation =
     /// Emit a lowered compilation as a .NET assembly.
     ///
     /// When the bound tree contains errors, emission is skipped and only the
-    /// diagnostics are returned.
+    /// diagnostics are returned. Returns `CompilationOutput` so the caller can
+    /// pass it to `createDerived` for REPL chaining.
     let emit compilation outputStream outputName symbolStream =
-        let assmName =
+        let assmName, newRefTypes =
             if not (hasErrors compilation.BoundTree.Diagnostics) then
-                compilation.BoundTree
-                |> Instrumentation.withPhase "emit" (fun lowered ->
-                    Emit.emit
-                        compilation.Options
-                        compilation.Target
-                        outputStream
-                        outputName
-                        symbolStream
-                        compilation.RefTypes
-                        lowered)
-                |> Some
+                let assmName, emittedTypes =
+                    compilation.BoundTree
+                    |> Instrumentation.withPhase "emit" (fun lowered ->
+                        Emit.emit
+                            compilation.Options
+                            compilation.Target
+                            outputStream
+                            outputName
+                            symbolStream
+                            compilation.RefTypes
+                            lowered)
+
+                Some assmName, List.append compilation.RefTypes emittedTypes
             else
-                None
+                None, compilation.RefTypes
 
         Instrumentation.compilationCount.Add 1L
 
@@ -143,14 +169,23 @@ module Compilation =
         )
 
         { Diagnostics = compilation.BoundTree.Diagnostics
-          EmittedAssemblyName = assmName }
+          EmittedAssemblyName = assmName
+          OutputScope = compilation.OutputScope
+          Options = compilation.Options
+          Target = compilation.Target
+          RefTypes = newRefTypes
+          StepIndex = 0 }
 
     /// Bind, lower, and emit in a single call.
     ///
     /// Sugar over `create` + `emit`. Preserves the existing call-site signature
     /// for callers that don't need scope chaining.
     let compile options outputStream outputName symbolStream input =
-        create options input |> fun c -> emit c outputStream outputName symbolStream
+        let output =
+            create options input |> fun c -> emit c outputStream outputName symbolStream
+
+        { Diagnostics = output.Diagnostics
+          EmittedAssemblyName = output.EmittedAssemblyName }
 
     // -- File-level entry points ----------------------------------------------
 

--- a/src/Feersum.CompilerServices/Compile/Compiler.fs
+++ b/src/Feersum.CompilerServices/Compile/Compiler.fs
@@ -20,33 +20,41 @@ type CompileInput =
     | Program of FileCollection
     | Script of SyntaxRoot<ScriptProgram>
 
+/// A bound and lowered program unit, ready for optional emission.
+[<NoComparison; NoEquality>]
+type Compilation =
+    { /// Lowered bound tree. Binding diagnostics live here.
+      BoundTree: BoundSyntaxTree
+      /// All top-level definitions introduced by this unit.
+      /// Pass to `Compilation.createDerived` for REPL chaining.
+      OutputScope: Scope
+      /// Retained for `Compilation.emit`.
+      Options: CompilationOptions
+      /// Retained for `Compilation.emit`.
+      Target: TargetInfo
+      /// External type references from referenced assemblies, retained for `Compilation.emit`.
+      RefTypes: TypeDefinition list }
+
 module Compilation =
 
-    /// Compile a single AST node into an assembly
-    ///
-    /// The plan for this is we make multiple passes over the syntax tree. First
-    /// pass will be to `bind` theh tree. Resulting in a `BoundExpr`. This will
-    /// attach any type information that _can_ be computed to each node, and
-    /// resolve variable references to the symbols that they refer to.
-    ///
-    /// Once the expression is bound we will then `emit` the expression this walks
-    /// the expression and writes out the corresponding .NET IL to an `Assembly`
-    /// at `outputStream`. The `outputName` controls the root namespace and assembly
-    /// name of the output.
-    let compile options outputStream outputName symbolStream (input: CompileInput) =
-        let target =
-            match options.FrameworkAssmPaths with
-            | [] -> TargetResolve.fromCurrentRuntime
-            | paths -> TargetResolve.fromFrameworkPaths paths
+    // -- Helpers --------------------------------------------------------------
 
+    let private resolveTarget options =
+        match options.FrameworkAssmPaths with
+        | [] -> TargetResolve.fromCurrentRuntime
+        | paths -> TargetResolve.fromFrameworkPaths paths
+
+    let private loadReferences options target =
         let coreLibs = Builtins.loadCoreSignatures target
 
-        let refTys, allLibs =
-            options.References
-            |> Seq.map (Builtins.loadReferencedSignatures)
-            |> Seq.append (Seq.singleton <| coreLibs)
-            |> Seq.fold (fun (tys, sigs) (aTys, aSigs) -> (List.append tys aTys, List.append sigs aSigs)) ([], [])
+        options.References
+        |> Seq.map Builtins.loadReferencedSignatures
+        |> Seq.append (Seq.singleton coreLibs)
+        |> Seq.fold
+            (fun (tys, sigs) (aTys, aSigs) -> List.append tys aTys, List.append sigs aSigs)
+            ([], [])
 
+    let private buildScope options allLibs =
         let baseScope =
             if options.OutputType = OutputType.Script then
                 Scope.ofLibraries allLibs
@@ -54,13 +62,10 @@ module Compilation =
                 { Scope.empty with Libs = allLibs }
 
         let macros, stxEnv = Builtins.loadBuiltinMacroEnv baseScope.StxEnv
+        { baseScope with StxEnv = stxEnv; Macros = macros }
 
-        let inputScope =
-            { baseScope with
-                StxEnv = stxEnv
-                Macros = macros }
-
-        let bound, _ =
+    let private bindAndLower inputScope input =
+        let bound, outputScope =
             Instrumentation.withPhase
                 "bind"
                 (fun () ->
@@ -69,27 +74,83 @@ module Compilation =
                     | CompileInput.Script script -> Binder.bindScript inputScope script)
                 ()
 
+        let lowered = Instrumentation.withPhase "lower" Lower.lower bound
+        lowered, outputScope
+
+    // -- Public API -----------------------------------------------------------
+
+    /// Bind and lower a program or script.
+    ///
+    /// Resolves references and builds the initial scope from `options`. The
+    /// returned `Compilation` can be passed to `emit` to write an assembly, or
+    /// inspected directly for diagnostics and the bound tree without emitting.
+    let create options input =
+        let target = resolveTarget options
+        let refTys, allLibs = loadReferences options target
+        let inputScope = buildScope options allLibs
+        let lowered, outputScope = bindAndLower inputScope input
+
+        { BoundTree = lowered
+          OutputScope = outputScope
+          Options = options
+          Target = target
+          RefTypes = refTys }
+
+    /// Bind and lower, deriving the scope from a previous compilation.
+    ///
+    /// Inherits `Target`, `RefTypes`, and `Options` from `previous` (reference
+    /// loading is skipped). Uses `previous.OutputScope` as the input scope so
+    /// all top-level definitions from prior steps remain visible — the correct
+    /// entry point for REPL chaining.
+    let createDerived previous input =
+        let lowered, outputScope = bindAndLower previous.OutputScope input
+
+        { BoundTree = lowered
+          OutputScope = outputScope
+          Options = previous.Options
+          Target = previous.Target
+          RefTypes = previous.RefTypes }
+
+    /// Emit a lowered compilation as a .NET assembly.
+    ///
+    /// When the bound tree contains errors, emission is skipped and only the
+    /// diagnostics are returned.
+    let emit compilation outputStream outputName symbolStream =
         let assmName =
-            if hasErrors bound.Diagnostics |> not then
-                bound
-                |> Instrumentation.withPhase "lower" Lower.lower
+            if not (hasErrors compilation.BoundTree.Diagnostics) then
+                compilation.BoundTree
                 |> Instrumentation.withPhase "emit" (fun lowered ->
-                    Emit.emit options target outputStream outputName symbolStream refTys lowered)
+                    Emit.emit
+                        compilation.Options
+                        compilation.Target
+                        outputStream
+                        outputName
+                        symbolStream
+                        compilation.RefTypes
+                        lowered)
                 |> Some
             else
                 None
 
-        Instrumentation.compilationCount.Add(1L)
+        Instrumentation.compilationCount.Add 1L
 
-        Instrumentation.compilationErrors.Add(bound.Diagnostics |> Seq.sumBy (fun d -> if isError d then 1L else 0L))
+        Instrumentation.compilationErrors.Add(
+            compilation.BoundTree.Diagnostics
+            |> Seq.sumBy (fun d -> if isError d then 1L else 0L))
 
-        { Diagnostics = bound.Diagnostics
+        { Diagnostics = compilation.BoundTree.Diagnostics
           EmittedAssemblyName = assmName }
 
-    /// Read a collection of Files and Compile
+    /// Bind, lower, and emit in a single call.
     ///
-    /// Takes the `sources` to an input to read and compile. Compilation results
-    /// are written to `output`.
+    /// Sugar over `create` + `emit`. Preserves the existing call-site signature
+    /// for callers that don't need scope chaining.
+    let compile options outputStream outputName symbolStream input =
+        create options input |> fun c -> emit c outputStream outputName symbolStream
+
+    // -- File-level entry points ----------------------------------------------
+
+    /// Read a collection of files and compile them to an assembly at `output`.
     let compileFiles (options: CompilationOptions) (output: string) (sources: string list) =
 
         // Handle the case that the user has specified a path to a directory but
@@ -101,17 +162,14 @@ module Compilation =
                 else
                     output, sprintf "%s%c" output Path.DirectorySeparatorChar
             else
-                // Ensure the output path exists
                 let dir = Path.GetDirectoryName(output)
 
                 if not (String.IsNullOrWhiteSpace dir) then
-                    // ensure the output directory exists, no need to check it is missing first
                     Directory.CreateDirectory(dir) |> ignore
 
                 dir, output
 
-        // Normalise the stem and output path. This ensures the output is a file
-        // not a directory.
+        // Normalise the stem and output path.
         let output =
             if String.IsNullOrWhiteSpace(Path.GetFileName(output)) then
                 Path.ChangeExtension(
@@ -123,17 +181,13 @@ module Compilation =
 
         let result = FileCollection.ofPaths sources
 
-        if Diagnostics.hasErrors result.Diagnostics then
+        if hasErrors result.Diagnostics then
             result.Diagnostics
         else
-
-            // Open the output streams. We don't use an `Option` directly here for
-            // the symbols stream so we can drop it with `use`.
             use outputStream = File.OpenWrite output
 
             use symbols =
                 match options.Configuration with
-                // make a symbol file
                 | BuildConfiguration.Debug -> File.OpenWrite(Path.ChangeExtension(output, "pdb")) :> Stream
                 | BuildConfiguration.Release -> null
 
@@ -143,17 +197,14 @@ module Compilation =
                     outputStream
                     (Path.GetFileName output)
                     (symbols |> Option.ofObj)
-                    (CompileInput.Program(result.Root))
+                    (CompileInput.Program result.Root)
 
-            if (hasErrors result.Diagnostics |> not) && options.OutputType = OutputType.Exe then
+            if not (hasErrors result.Diagnostics) && options.OutputType = Exe then
                 match result.EmittedAssemblyName with
                 | Some assemblyName -> Runtime.writeRuntimeConfig options output assemblyName outDir
                 | None -> ()
 
             result.Diagnostics
 
-    /// Read a File and Compile
-    ///
-    /// Takes the `source` to an input to read and compile. Compilation results
-    /// are written to `output`.
+    /// Read a single file and compile it to an assembly at `output`.
     let compileFile options output source = compileFiles options output [ source ]

--- a/src/Feersum.CompilerServices/Compile/Compiler.fs
+++ b/src/Feersum.CompilerServices/Compile/Compiler.fs
@@ -7,7 +7,6 @@ open Mono.Cecil
 open Feersum.CompilerServices
 open Feersum.CompilerServices.Diagnostics
 open Feersum.CompilerServices.Binding
-open Feersum.CompilerServices.Syntax
 open Feersum.CompilerServices.Targets
 open Feersum.CompilerServices.Syntax.Tree
 open Feersum.CompilerServices.Syntax.Parse
@@ -49,22 +48,26 @@ module Compilation =
             |> Seq.append (Seq.singleton <| coreLibs)
             |> Seq.fold (fun (tys, sigs) (aTys, aSigs) -> (List.append tys aTys, List.append sigs aSigs)) ([], [])
 
-        let preloaded =
+        let baseScope =
             if options.OutputType = OutputType.Script then
-                Environments.fromLibraries allLibs
+                Scope.ofLibraries allLibs
             else
-                Environments.empty
+                { Scope.empty with Libs = allLibs }
 
-        let bound =
+        let macros, stxEnv = Builtins.loadBuiltinMacroEnv baseScope.StxEnv
+
+        let inputScope =
+            { baseScope with
+                StxEnv = stxEnv
+                Macros = macros }
+
+        let bound, _ =
             Instrumentation.withPhase
                 "bind"
                 (fun () ->
-                    let stxEnv, refEnv = Environments.intoParts preloaded
-                    let macros, stxEnv = Builtins.loadBuiltinMacroEnv stxEnv
-
                     match input with
-                    | CompileInput.Program progs -> Binder.bindProgram stxEnv refEnv allLibs macros progs
-                    | CompileInput.Script script -> Binder.bindScript stxEnv refEnv allLibs macros script)
+                    | CompileInput.Program progs -> Binder.bindProgram inputScope progs
+                    | CompileInput.Script script -> Binder.bindScript inputScope script)
                 ()
 
         let assmName =
@@ -119,12 +122,7 @@ module Compilation =
             else
                 output
 
-        let result =
-            sources
-            |> Seq.map (fun path ->
-                let contents = File.ReadAllText(path)
-                Parse.readProgram path contents)
-            |> ParseResult.fold (fun progs p -> List.append progs [ p ]) []
+        let result = FileCollection.ofPaths sources
 
         if Diagnostics.hasErrors result.Diagnostics then
             result.Diagnostics

--- a/src/Feersum.CompilerServices/Compile/Compiler.fs
+++ b/src/Feersum.CompilerServices/Compile/Compiler.fs
@@ -17,11 +17,10 @@ type CompileResult =
 
 [<RequireQualifiedAccess>]
 type CompileInput =
-    | Program of SyntaxRoot<Program> list
+    | Program of FileCollection
     | Script of SyntaxRoot<ScriptProgram>
 
 module Compilation =
-    open Feersum.CompilerServices.Syntax.Parse
 
     /// Compile a single AST node into an assembly
     ///

--- a/src/Feersum.CompilerServices/Compile/Compiler.fs
+++ b/src/Feersum.CompilerServices/Compile/Compiler.fs
@@ -23,17 +23,19 @@ type CompileInput =
 /// A bound and lowered program unit, ready for optional emission.
 [<NoComparison; NoEquality>]
 type Compilation =
-    { /// Lowered bound tree. Binding diagnostics live here.
-      BoundTree: BoundSyntaxTree
-      /// All top-level definitions introduced by this unit.
-      /// Pass to `Compilation.createDerived` for REPL chaining.
-      OutputScope: Scope
-      /// Retained for `Compilation.emit`.
-      Options: CompilationOptions
-      /// Retained for `Compilation.emit`.
-      Target: TargetInfo
-      /// External type references from referenced assemblies, retained for `Compilation.emit`.
-      RefTypes: TypeDefinition list }
+    {
+        /// Lowered bound tree. Binding diagnostics live here.
+        BoundTree: BoundSyntaxTree
+        /// All top-level definitions introduced by this unit.
+        /// Pass to `Compilation.createDerived` for REPL chaining.
+        OutputScope: Scope
+        /// Retained for `Compilation.emit`.
+        Options: CompilationOptions
+        /// Retained for `Compilation.emit`.
+        Target: TargetInfo
+        /// External type references from referenced assemblies, retained for `Compilation.emit`.
+        RefTypes: TypeDefinition list
+    }
 
 module Compilation =
 
@@ -50,9 +52,7 @@ module Compilation =
         options.References
         |> Seq.map Builtins.loadReferencedSignatures
         |> Seq.append (Seq.singleton coreLibs)
-        |> Seq.fold
-            (fun (tys, sigs) (aTys, aSigs) -> List.append tys aTys, List.append sigs aSigs)
-            ([], [])
+        |> Seq.fold (fun (tys, sigs) (aTys, aSigs) -> List.append tys aTys, List.append sigs aSigs) ([], [])
 
     let private buildScope options allLibs =
         let baseScope =
@@ -62,7 +62,10 @@ module Compilation =
                 { Scope.empty with Libs = allLibs }
 
         let macros, stxEnv = Builtins.loadBuiltinMacroEnv baseScope.StxEnv
-        { baseScope with StxEnv = stxEnv; Macros = macros }
+
+        { baseScope with
+            StxEnv = stxEnv
+            Macros = macros }
 
     let private bindAndLower inputScope input =
         let bound, outputScope =
@@ -136,7 +139,8 @@ module Compilation =
 
         Instrumentation.compilationErrors.Add(
             compilation.BoundTree.Diagnostics
-            |> Seq.sumBy (fun d -> if isError d then 1L else 0L))
+            |> Seq.sumBy (fun d -> if isError d then 1L else 0L)
+        )
 
         { Diagnostics = compilation.BoundTree.Diagnostics
           EmittedAssemblyName = assmName }

--- a/src/Feersum.CompilerServices/Compile/Compiler.fs
+++ b/src/Feersum.CompilerServices/Compile/Compiler.fs
@@ -37,9 +37,9 @@ type Compilation =
         RefTypes: TypeDefinition list
     }
 
-/// The result of emitting a `Compilation`. Carries everything `createDerived`
-/// needs to chain the next REPL step: the output scope, accumulated extern
-/// types (prior steps included), and step index for unique type naming.
+/// The result of emitting a `Compilation`. Carries everything `createChained`
+/// needs to chain the next REPL step: the output scope and accumulated extern
+/// types (original references plus every type emitted by prior REPL steps).
 [<NoComparison; NoEquality>]
 type CompilationOutput =
     {
@@ -52,9 +52,6 @@ type CompilationOutput =
         /// type emitted by prior REPL steps. Passed as `externTys` to Emit.emit
         /// in the next step so previous globals are reachable as extern fields.
         RefTypes: TypeDefinition list
-        /// Monotonically increasing step counter. Incremented by `createDerived`
-        /// to produce a unique `ProgramName` for each REPL compilation.
-        StepIndex: int
     }
 
 module Compilation =
@@ -119,15 +116,16 @@ module Compilation =
           Target = target
           RefTypes = refTys }
 
-    /// Bind and lower, deriving the scope from a previous emit output.
+    /// Bind and lower, chaining scope from a previous emit output.
     ///
     /// Inherits `Target`, `RefTypes`, and `Options` from `previous` (reference
-    /// loading is skipped). Uses `previous.OutputScope` as the input scope,
-    /// with an incremented `ProgramName` so each REPL step emits a unique type.
-    let createDerived (previous: CompilationOutput) input =
+    /// loading is skipped). Uses `previous.OutputScope` as the input scope so
+    /// all prior top-level definitions remain visible. The caller supplies
+    /// `programName` to give each REPL step a distinct type name.
+    let createChained (previous: CompilationOutput) (programName: string) input =
         let nextScope =
             { previous.OutputScope with
-                ProgramName = sprintf "LispProgram_%d" (previous.StepIndex + 1) }
+                ProgramName = programName }
 
         let lowered, outputScope = bindAndLower nextScope input
 
@@ -141,7 +139,7 @@ module Compilation =
     ///
     /// When the bound tree contains errors, emission is skipped and only the
     /// diagnostics are returned. Returns `CompilationOutput` so the caller can
-    /// pass it to `createDerived` for REPL chaining.
+    /// pass it to `createChained` for REPL chaining.
     let emit compilation outputStream outputName symbolStream =
         let assmName, newRefTypes =
             if not (hasErrors compilation.BoundTree.Diagnostics) then
@@ -173,8 +171,7 @@ module Compilation =
           OutputScope = compilation.OutputScope
           Options = compilation.Options
           Target = compilation.Target
-          RefTypes = newRefTypes
-          StepIndex = 0 }
+          RefTypes = newRefTypes }
 
     /// Bind, lower, and emit in a single call.
     ///

--- a/src/Feersum.CompilerServices/Compile/Compiler.fs
+++ b/src/Feersum.CompilerServices/Compile/Compiler.fs
@@ -11,35 +11,28 @@ open Feersum.CompilerServices.Targets
 open Feersum.CompilerServices.Syntax.Tree
 open Feersum.CompilerServices.Syntax.Parse
 
-type CompileResult =
-    { Diagnostics: Diagnostic list
-      EmittedAssemblyName: AssemblyNameDefinition option }
-
 [<RequireQualifiedAccess>]
 type CompileInput =
     | Program of FileCollection
     | Script of SyntaxRoot<ScriptProgram>
 
 /// A bound and lowered program unit, ready for optional emission.
+/// Returned by `Compilation.bind`; can be passed to tooling (e.g. LSP) that
+/// needs the bound tree without producing an assembly.
 [<NoComparison; NoEquality>]
-type Compilation =
+type BindResult =
     {
         /// Lowered bound tree. Binding diagnostics live here.
         BoundTree: BoundSyntaxTree
         /// All top-level definitions introduced by this unit.
-        /// Pass to `Compilation.createDerived` for REPL chaining.
         OutputScope: Scope
-        /// Retained for `Compilation.emit`.
         Options: CompilationOptions
-        /// Retained for `Compilation.emit`.
         Target: TargetInfo
-        /// External type references from referenced assemblies, retained for `Compilation.emit`.
         RefTypes: TypeDefinition list
     }
 
-/// The result of emitting a `Compilation`. Carries everything `createChained`
-/// needs to chain the next REPL step: the output scope and accumulated extern
-/// types (original references plus every type emitted by prior REPL steps).
+/// The result of a full compilation (bind + emit). Carries everything needed
+/// to chain the next REPL step via `CompileContext.Chained`.
 [<NoComparison; NoEquality>]
 type CompilationOutput =
     {
@@ -53,6 +46,15 @@ type CompilationOutput =
         /// in the next step so previous globals are reachable as extern fields.
         RefTypes: TypeDefinition list
     }
+
+/// The starting point for `Compilation.compile`: either a fresh set of options
+/// or the output of a prior compilation to chain from (REPL use).
+[<RequireQualifiedAccess>]
+type CompileContext =
+    | Fresh of CompilationOptions
+    /// Chain from a previous emit output. `programName` sets the type name for
+    /// globals in this step so each REPL step uses a unique, non-colliding name.
+    | Chained of previous: CompilationOutput * programName: string
 
 module Compilation =
 
@@ -97,14 +99,46 @@ module Compilation =
         let lowered = Instrumentation.withPhase "lower" Lower.lower bound
         lowered, outputScope
 
+    let private emitBound (bound: BindResult) outputStream outputName symbolStream =
+        let assmName, newRefTypes =
+            if not (hasErrors bound.BoundTree.Diagnostics) then
+                let assmName, emittedTypes =
+                    bound.BoundTree
+                    |> Instrumentation.withPhase "emit" (fun lowered ->
+                        Emit.emit
+                            bound.Options
+                            bound.Target
+                            outputStream
+                            outputName
+                            symbolStream
+                            bound.RefTypes
+                            lowered)
+
+                Some assmName, List.append bound.RefTypes emittedTypes
+            else
+                None, bound.RefTypes
+
+        Instrumentation.compilationCount.Add 1L
+
+        Instrumentation.compilationErrors.Add(
+            bound.BoundTree.Diagnostics |> Seq.sumBy (fun d -> if isError d then 1L else 0L)
+        )
+
+        { Diagnostics = bound.BoundTree.Diagnostics
+          EmittedAssemblyName = assmName
+          OutputScope = bound.OutputScope
+          Options = bound.Options
+          Target = bound.Target
+          RefTypes = newRefTypes }
+
     // -- Public API -----------------------------------------------------------
 
-    /// Bind and lower a program or script.
+    /// Bind and lower a program or script without emitting an assembly.
     ///
-    /// Resolves references and builds the initial scope from `options`. The
-    /// returned `Compilation` can be passed to `emit` to write an assembly, or
-    /// inspected directly for diagnostics and the bound tree without emitting.
-    let create options input =
+    /// Use this when only the bound tree is needed (e.g. LSP diagnostics,
+    /// hover, go-to-definition). Pass the returned `BindResult` to
+    /// `Compilation.compile` to emit when required.
+    let bind options input =
         let target = resolveTarget options
         let refTys, allLibs = loadReferences options target
         let inputScope = buildScope options allLibs
@@ -116,73 +150,29 @@ module Compilation =
           Target = target
           RefTypes = refTys }
 
-    /// Bind and lower, chaining scope from a previous emit output.
+    /// Bind and emit a program or script in one step.
     ///
-    /// Inherits `Target`, `RefTypes`, and `Options` from `previous` (reference
-    /// loading is skipped). Uses `previous.OutputScope` as the input scope so
-    /// all prior top-level definitions remain visible. The caller supplies
-    /// `programName` to give each REPL step a distinct type name.
-    let createChained (previous: CompilationOutput) (programName: string) input =
-        let nextScope =
-            { previous.OutputScope with
-                ProgramName = programName }
+    /// Supply `CompileContext.Fresh options` for a standalone compilation or
+    /// `CompileContext.Chained(previous, programName)` to inherit scope and
+    /// references from a prior REPL step.
+    let compile (context: CompileContext) input outputStream outputName symbolStream =
+        let bound =
+            match context with
+            | CompileContext.Fresh options -> bind options input
+            | CompileContext.Chained(previous, programName) ->
+                let nextScope =
+                    { previous.OutputScope with
+                        ProgramName = programName }
 
-        let lowered, outputScope = bindAndLower nextScope input
+                let lowered, outputScope = bindAndLower nextScope input
 
-        { BoundTree = lowered
-          OutputScope = outputScope
-          Options = previous.Options
-          Target = previous.Target
-          RefTypes = previous.RefTypes }
+                { BoundTree = lowered
+                  OutputScope = outputScope
+                  Options = previous.Options
+                  Target = previous.Target
+                  RefTypes = previous.RefTypes }
 
-    /// Emit a lowered compilation as a .NET assembly.
-    ///
-    /// When the bound tree contains errors, emission is skipped and only the
-    /// diagnostics are returned. Returns `CompilationOutput` so the caller can
-    /// pass it to `createChained` for REPL chaining.
-    let emit compilation outputStream outputName symbolStream =
-        let assmName, newRefTypes =
-            if not (hasErrors compilation.BoundTree.Diagnostics) then
-                let assmName, emittedTypes =
-                    compilation.BoundTree
-                    |> Instrumentation.withPhase "emit" (fun lowered ->
-                        Emit.emit
-                            compilation.Options
-                            compilation.Target
-                            outputStream
-                            outputName
-                            symbolStream
-                            compilation.RefTypes
-                            lowered)
-
-                Some assmName, List.append compilation.RefTypes emittedTypes
-            else
-                None, compilation.RefTypes
-
-        Instrumentation.compilationCount.Add 1L
-
-        Instrumentation.compilationErrors.Add(
-            compilation.BoundTree.Diagnostics
-            |> Seq.sumBy (fun d -> if isError d then 1L else 0L)
-        )
-
-        { Diagnostics = compilation.BoundTree.Diagnostics
-          EmittedAssemblyName = assmName
-          OutputScope = compilation.OutputScope
-          Options = compilation.Options
-          Target = compilation.Target
-          RefTypes = newRefTypes }
-
-    /// Bind, lower, and emit in a single call.
-    ///
-    /// Sugar over `create` + `emit`. Preserves the existing call-site signature
-    /// for callers that don't need scope chaining.
-    let compile options outputStream outputName symbolStream input =
-        let output =
-            create options input |> fun c -> emit c outputStream outputName symbolStream
-
-        { Diagnostics = output.Diagnostics
-          EmittedAssemblyName = output.EmittedAssemblyName }
+        emitBound bound outputStream outputName symbolStream
 
     // -- File-level entry points ----------------------------------------------
 
@@ -229,11 +219,11 @@ module Compilation =
 
             let result =
                 compile
-                    options
+                    (CompileContext.Fresh options)
+                    (CompileInput.Program result.Root)
                     outputStream
                     (Path.GetFileName output)
                     (symbols |> Option.ofObj)
-                    (CompileInput.Program result.Root)
 
             if not (hasErrors result.Diagnostics) && options.OutputType = Exe then
                 match result.EmittedAssemblyName with

--- a/src/Feersum.CompilerServices/Compile/Emit.fs
+++ b/src/Feersum.CompilerServices/Compile/Emit.fs
@@ -141,7 +141,7 @@ module private Utils =
             |> Seq.tryFind (fun f -> f.Name = id)
             |> Option.defaultWith (fun () ->
                 let newField =
-                    FieldDefinition(id, FieldAttributes.Static, ctx.Assm.MainModule.TypeSystem.Object)
+                    FieldDefinition(id, FieldAttributes.Static ||| FieldAttributes.Public, ctx.Assm.MainModule.TypeSystem.Object)
 
                 if ctx.ProgramTy <> ty then
                     icef "Type %A does not match %A being modified for field %s" ctx.ProgramTy ty id
@@ -1028,10 +1028,20 @@ module Emit =
         (bound: BoundSyntaxTree)
         =
 
-        /// Collect external types so we can look up their fields later
+        // Collect external types so we can look up their fields later.
+        // Index by both FullName (for library types referenced via ty.FullName
+        // in StorageRef, e.g. "Serehfa.Write") and by Name (for REPL-chained
+        // program types referenced by MangledName, e.g. "LispProgram_0").
+        // When both keys are the same (no-namespace type) the entry is deduped.
         let externs =
             externTys
-            |> Seq.map (fun (ty: TypeDefinition) -> (ty.FullName, ty))
+            |> Seq.collect (fun (ty: TypeDefinition) ->
+                seq {
+                    yield ty.FullName, ty
+
+                    if ty.Name <> ty.FullName then
+                        yield ty.Name, ty
+                })
             |> Map.ofSeq
 
         // Create an assembly with a nominal version to hold our code
@@ -1121,4 +1131,10 @@ module Emit =
         | None -> ()
 
         assm.Write(outputStream, writerParams)
-        name
+        // Collect all non-nested types emitted into this assembly. These are
+        // captured before any GC could collect the AssemblyDefinition; the
+        // TypeDefinitions hold a back-reference to their module keeping it alive.
+        let emittedTypes =
+            assm.MainModule.Types |> Seq.filter (fun t -> not t.IsNested) |> Seq.toList
+
+        name, emittedTypes

--- a/src/Feersum.CompilerServices/Compile/Emit.fs
+++ b/src/Feersum.CompilerServices/Compile/Emit.fs
@@ -141,7 +141,11 @@ module private Utils =
             |> Seq.tryFind (fun f -> f.Name = id)
             |> Option.defaultWith (fun () ->
                 let newField =
-                    FieldDefinition(id, FieldAttributes.Static ||| FieldAttributes.Public, ctx.Assm.MainModule.TypeSystem.Object)
+                    FieldDefinition(
+                        id,
+                        FieldAttributes.Static ||| FieldAttributes.Public,
+                        ctx.Assm.MainModule.TypeSystem.Object
+                    )
 
                 if ctx.ProgramTy <> ty then
                     icef "Type %A does not match %A being modified for field %s" ctx.ProgramTy ty id
@@ -1029,10 +1033,10 @@ module Emit =
         =
 
         // Collect external types so we can look up their fields later.
-        // Index by both FullName (for library types referenced via ty.FullName
-        // in StorageRef, e.g. "Serehfa.Write") and by Name (for REPL-chained
-        // program types referenced by MangledName, e.g. "LispProgram_0").
-        // When both keys are the same (no-namespace type) the entry is deduped.
+        // Library types (e.g. "Serehfa.Write") are keyed by FullName, which is
+        // what Builtins stores in StorageRef.Global. Emitted REPL types are also
+        // indexed by their short Name so the binder's MangledName-keyed
+        // StorageRef.Global entries resolve correctly across REPL steps.
         let externs =
             externTys
             |> Seq.collect (fun (ty: TypeDefinition) ->

--- a/src/Feersum.CompilerServices/Eval.fs
+++ b/src/Feersum.CompilerServices/Eval.fs
@@ -79,22 +79,26 @@ let private invokeAssembly (ctx: EvalContext) (bytes: byte[]) (typeName: string)
 /// errors the original context is returned unchanged so the caller's
 /// accumulated scope is preserved.
 let evalInContext (ctx: EvalContext) input =
-    let compilation =
+    // Derive the program type name before compiling so we can look it up by
+    // reflection after loading — CompilationOutput doesn't carry BoundTree.
+    let programName, context =
         match ctx.State with
-        | None -> Compilation.create ctx.Options input
+        | None -> "LispProgram", CompileContext.Fresh ctx.Options
         | Some prev ->
-            let programName = sprintf "LispProgram_%d" ctx.StepIndex
-            Compilation.createChained prev programName input
+            let name = sprintf "LispProgram_%d" ctx.StepIndex
+            name, CompileContext.Chained(prev, name)
 
-    if not compilation.BoundTree.Diagnostics.IsEmpty then
-        Error compilation.BoundTree.Diagnostics, ctx
-    else
-        use memStream = new MemoryStream()
-        // Each step gets a unique assembly name so the load context can hold
-        // all steps simultaneously without name collisions.
-        let assmStem = sprintf "evalCtx_%d" ctx.StepIndex
-        let output = Compilation.emit compilation memStream (assmStem + ".dll") None
-        let typeName = sprintf "%s.%s" assmStem compilation.BoundTree.MangledName
+    use memStream = new MemoryStream()
+    // Each step gets a unique assembly name so the load context can hold
+    // all steps simultaneously without name collisions.
+    let assmStem = sprintf "evalCtx_%d" ctx.StepIndex
+    let output = Compilation.compile context input memStream (assmStem + ".dll") None
+
+    // emitBound skips emission and returns None when there are bind errors.
+    match output.EmittedAssemblyName with
+    | None -> Error output.Diagnostics, ctx
+    | Some _ ->
+        let typeName = sprintf "%s.%s" assmStem programName
         let bytes = memStream.ToArray()
 
         match invokeAssembly ctx bytes typeName with

--- a/src/Feersum.CompilerServices/Eval.fs
+++ b/src/Feersum.CompilerServices/Eval.fs
@@ -18,36 +18,44 @@ let defaultScriptOptions = CompilationOptions.Create Debug Script
 /// Returns the external representation for a CIL type.
 let cilExternalRepr (object: Object) = Write.GetExternalRepresentation(object)
 
-/// Take a syntax tree and evaluate it in-process
-///
-/// This first compiles the tree to an in-memory assembly and then calls the
-/// main method on that.
-///
-/// The script is compiled using `options`
-let evalWith options input =
-    use memStream = new MemoryStream()
+/// Invoke a successfully-emitted assembly's script body.
+let private invokeAssembly (memStream: MemoryStream) =
+    let assm = Assembly.Load(memStream.ToArray())
+    let progTy = assm.GetType "evalCtx.LispProgram"
+    let mainMethod = progTy.GetMethod "$ScriptBody"
 
-    let result = Compilation.compile options memStream "evalCtx" None input
+    try
+        Ok(mainMethod.Invoke(null, Array.empty<obj>))
+    with :? TargetInvocationException as ex ->
+        // Unwrap target invocation exceptions to give the REPL a nicer experience.
+        ExceptionDispatchInfo.Capture(ex.InnerException).Throw()
+        Error []
 
-    if not result.Diagnostics.IsEmpty then
-        Error(result.Diagnostics)
+/// Evaluate a script, deriving scope from a previous compilation when given.
+///
+/// Returns the runtime result paired with the compilation to pass to the next
+/// step. On a bind error the `previous` compilation is returned unchanged so
+/// the caller's accumulated scope is preserved.
+let evalWithPrev (previous: Compilation option) options input =
+    let c =
+        match previous with
+        | None -> Compilation.create options input
+        | Some prev -> Compilation.createDerived prev input
+
+    if not c.BoundTree.Diagnostics.IsEmpty then
+        Error c.BoundTree.Diagnostics, previous
     else
-        let assm = Assembly.Load(memStream.ToArray())
-        let progTy = assm.GetType("evalCtx.LispProgram")
-        let mainMethod = progTy.GetMethod("$ScriptBody")
+        use memStream = new MemoryStream()
+        Compilation.emit c memStream "evalCtx" None |> ignore
+        invokeAssembly memStream |> Result.mapError (fun _ -> []), Some c
 
-        try
-            Ok(mainMethod.Invoke(null, Array.empty<obj>))
-        with :? TargetInvocationException as ex ->
-            // Unwrap target invocation exceptions a little to make the REPL a
-            // bit of a nicer experience
-            ExceptionDispatchInfo.Capture(ex.InnerException).Throw()
-
-            Error([])
-
-/// Take a syntax tree and evaluate it in-process
+/// Take a syntax tree and evaluate it in-process.
 ///
-/// This first compiles the tree to an in-memory assembly and then calls the
-/// main method on that. This is the same os calling `evalWith` using the
-/// `defaultScriptoptions`.
+/// Compiles to an in-memory assembly and invokes the script body. Uses
+/// `options` for compilation settings. Does not chain scope between calls;
+/// use `evalWithPrev` for REPL state accumulation.
+let evalWith options input =
+    evalWithPrev None options input |> fst
+
+/// Evaluate using the default script options.
 let eval = evalWith defaultScriptOptions

--- a/src/Feersum.CompilerServices/Eval.fs
+++ b/src/Feersum.CompilerServices/Eval.fs
@@ -54,8 +54,7 @@ let evalWithPrev (previous: Compilation option) options input =
 /// Compiles to an in-memory assembly and invokes the script body. Uses
 /// `options` for compilation settings. Does not chain scope between calls;
 /// use `evalWithPrev` for REPL state accumulation.
-let evalWith options input =
-    evalWithPrev None options input |> fst
+let evalWith options input = evalWithPrev None options input |> fst
 
 /// Evaluate using the default script options.
 let eval = evalWith defaultScriptOptions

--- a/src/Feersum.CompilerServices/Eval.fs
+++ b/src/Feersum.CompilerServices/Eval.fs
@@ -1,16 +1,18 @@
 module Feersum.CompilerServices.Eval
 
+open System.Collections.Generic
 open System.IO
 open System.Reflection
 open System
 open System.Runtime.ExceptionServices
+open System.Runtime.Loader
 
 open Serehfa
 
 open Feersum.CompilerServices
 open Feersum.CompilerServices.Compile
 
-/// The default set of otpions for scripting
+/// The default set of options for scripting
 let defaultScriptOptions = CompilationOptions.Create Debug Script
 
 /// Raw External Representation
@@ -18,43 +20,86 @@ let defaultScriptOptions = CompilationOptions.Create Debug Script
 /// Returns the external representation for a CIL type.
 let cilExternalRepr (object: Object) = Write.GetExternalRepresentation(object)
 
-/// Invoke a successfully-emitted assembly's script body.
-let private invokeAssembly (memStream: MemoryStream) =
-    let assm = Assembly.Load(memStream.ToArray())
-    let progTy = assm.GetType "evalCtx.LispProgram"
+/// An AssemblyLoadContext that retains every assembly loaded into it by name,
+/// so that cross-step references in a REPL session resolve correctly.
+type ReplLoadContext() =
+    inherit AssemblyLoadContext(isCollectible = false)
+    let loaded = Dictionary<string, Assembly>()
+
+    member this.LoadBytes(bytes: byte[]) =
+        use ms = new MemoryStream(bytes)
+        let assm = this.LoadFromStream ms
+        loaded.[assm.GetName().Name] <- assm
+        assm
+
+    override _.Load name =
+        match loaded.TryGetValue name.Name with
+        | true, a -> a
+        | _ -> null
+
+/// A session-scoped evaluation context. Holds compilation options, the
+/// shared assembly load context for REPL cross-step references, and the
+/// accumulated `CompilationOutput` from prior steps.
+///
+/// Dispose when the session ends to release the load context.
+[<NoComparison; NoEquality>]
+type EvalContext =
+    { Options: CompilationOptions
+      LoadContext: ReplLoadContext
+      mutable State: CompilationOutput option }
+
+    interface IDisposable with
+        member _.Dispose() = ()
+
+module EvalContext =
+    let create options =
+        { Options = options
+          LoadContext = ReplLoadContext()
+          State = None }
+
+/// Invoke a successfully-emitted assembly's script body via the given load context.
+let private invokeAssembly (ctx: EvalContext) (bytes: byte[]) (typeName: string) =
+    let assm = ctx.LoadContext.LoadBytes bytes
+    let progTy = assm.GetType typeName
     let mainMethod = progTy.GetMethod "$ScriptBody"
 
     try
         Ok(mainMethod.Invoke(null, Array.empty<obj>))
     with :? TargetInvocationException as ex ->
-        // Unwrap target invocation exceptions to give the REPL a nicer experience.
         ExceptionDispatchInfo.Capture(ex.InnerException).Throw()
         Error []
 
-/// Evaluate a script, deriving scope from a previous compilation when given.
-///
-/// Returns the runtime result paired with the compilation to pass to the next
-/// step. On a bind error the `previous` compilation is returned unchanged so
-/// the caller's accumulated scope is preserved.
-let evalWithPrev (previous: Compilation option) options input =
-    let c =
-        match previous with
-        | None -> Compilation.create options input
+/// Evaluate a script inside a given `EvalContext`, chaining scope from any
+/// previous step stored in `ctx.State`. Updates `ctx.State` on success.
+let evalInContext (ctx: EvalContext) input =
+    let nextIndex = ctx.State |> Option.map (fun s -> s.StepIndex + 1) |> Option.defaultValue 0
+
+    let compilation =
+        match ctx.State with
+        | None -> Compilation.create ctx.Options input
         | Some prev -> Compilation.createDerived prev input
 
-    if not c.BoundTree.Diagnostics.IsEmpty then
-        Error c.BoundTree.Diagnostics, previous
+    if not compilation.BoundTree.Diagnostics.IsEmpty then
+        Error compilation.BoundTree.Diagnostics
     else
         use memStream = new MemoryStream()
-        Compilation.emit c memStream "evalCtx" None |> ignore
-        invokeAssembly memStream |> Result.mapError (fun _ -> []), Some c
+        // Each step gets a unique assembly name so the load context can hold
+        // all steps simultaneously without name collisions.
+        let assmStem = sprintf "evalCtx_%d" nextIndex
+        let output = Compilation.emit compilation memStream (assmStem + ".dll") None
+        let typeName = sprintf "%s.%s" assmStem compilation.BoundTree.MangledName
+        let bytes = memStream.ToArray()
 
-/// Take a syntax tree and evaluate it in-process.
-///
-/// Compiles to an in-memory assembly and invokes the script body. Uses
-/// `options` for compilation settings. Does not chain scope between calls;
-/// use `evalWithPrev` for REPL state accumulation.
-let evalWith options input = evalWithPrev None options input |> fst
+        match invokeAssembly ctx bytes typeName with
+        | Ok value ->
+            ctx.State <- Some { output with StepIndex = nextIndex }
+            Ok value
+        | Error diags -> Error diags
+
+/// Evaluate using the given options without retaining any session state.
+let evalWith (options: CompilationOptions) input =
+    use ctx = EvalContext.create options
+    evalInContext ctx input
 
 /// Evaluate using the default script options.
 let eval = evalWith defaultScriptOptions

--- a/src/Feersum.CompilerServices/Eval.fs
+++ b/src/Feersum.CompilerServices/Eval.fs
@@ -22,8 +22,9 @@ let cilExternalRepr (object: Object) = Write.GetExternalRepresentation(object)
 
 /// An AssemblyLoadContext that retains every assembly loaded into it by name,
 /// so that cross-step references in a REPL session resolve correctly.
+/// Collectible so the entire session can be unloaded when disposed.
 type ReplLoadContext() =
-    inherit AssemblyLoadContext(isCollectible = false)
+    inherit AssemblyLoadContext(isCollectible = true)
     let loaded = Dictionary<string, Assembly>()
 
     member this.LoadBytes(bytes: byte[]) =
@@ -37,27 +38,29 @@ type ReplLoadContext() =
         | true, a -> a
         | _ -> null
 
-/// A session-scoped evaluation context. Holds compilation options, the
-/// shared assembly load context for REPL cross-step references, and the
-/// accumulated `CompilationOutput` from prior steps.
+/// A session-scoped evaluation context. Immutable value: `evalInContext`
+/// returns a new context rather than mutating the existing one.
 ///
-/// Dispose when the session ends to release the load context.
+/// The `LoadContext` is a shared reference type across all derived contexts.
+/// Call `Dispose` on the original context when the session ends to unload it.
 [<NoComparison; NoEquality>]
 type EvalContext =
     { Options: CompilationOptions
       LoadContext: ReplLoadContext
-      mutable State: CompilationOutput option }
+      State: CompilationOutput option
+      StepIndex: int }
 
     interface IDisposable with
-        member _.Dispose() = ()
+        member ctx.Dispose() = ctx.LoadContext.Unload()
 
 module EvalContext =
     let create options =
         { Options = options
           LoadContext = ReplLoadContext()
-          State = None }
+          State = None
+          StepIndex = 0 }
 
-/// Invoke a successfully-emitted assembly's script body via the given load context.
+/// Invoke the script body of an emitted assembly via the session load context.
 let private invokeAssembly (ctx: EvalContext) (bytes: byte[]) (typeName: string) =
     let assm = ctx.LoadContext.LoadBytes bytes
     let progTy = assm.GetType typeName
@@ -70,36 +73,44 @@ let private invokeAssembly (ctx: EvalContext) (bytes: byte[]) (typeName: string)
         Error []
 
 /// Evaluate a script inside a given `EvalContext`, chaining scope from any
-/// previous step stored in `ctx.State`. Updates `ctx.State` on success.
+/// previous step stored in `ctx.State`.
+///
+/// Returns the result and a new `EvalContext` with updated state. On bind
+/// errors the original context is returned unchanged so the caller's
+/// accumulated scope is preserved.
 let evalInContext (ctx: EvalContext) input =
-    let nextIndex = ctx.State |> Option.map (fun s -> s.StepIndex + 1) |> Option.defaultValue 0
-
     let compilation =
         match ctx.State with
         | None -> Compilation.create ctx.Options input
-        | Some prev -> Compilation.createDerived prev input
+        | Some prev ->
+            let programName = sprintf "LispProgram_%d" ctx.StepIndex
+            Compilation.createChained prev programName input
 
     if not compilation.BoundTree.Diagnostics.IsEmpty then
-        Error compilation.BoundTree.Diagnostics
+        Error compilation.BoundTree.Diagnostics, ctx
     else
         use memStream = new MemoryStream()
         // Each step gets a unique assembly name so the load context can hold
         // all steps simultaneously without name collisions.
-        let assmStem = sprintf "evalCtx_%d" nextIndex
+        let assmStem = sprintf "evalCtx_%d" ctx.StepIndex
         let output = Compilation.emit compilation memStream (assmStem + ".dll") None
         let typeName = sprintf "%s.%s" assmStem compilation.BoundTree.MangledName
         let bytes = memStream.ToArray()
 
         match invokeAssembly ctx bytes typeName with
         | Ok value ->
-            ctx.State <- Some { output with StepIndex = nextIndex }
-            Ok value
-        | Error diags -> Error diags
+            let nextCtx =
+                { ctx with
+                    State = Some output
+                    StepIndex = ctx.StepIndex + 1 }
+
+            Ok value, nextCtx
+        | Error diags -> Error diags, ctx
 
 /// Evaluate using the given options without retaining any session state.
 let evalWith (options: CompilationOptions) input =
     use ctx = EvalContext.create options
-    evalInContext ctx input
+    evalInContext ctx input |> fst
 
 /// Evaluate using the default script options.
 let eval = evalWith defaultScriptOptions

--- a/src/Feersum.CompilerServices/Syntax/Parse.fs
+++ b/src/Feersum.CompilerServices/Syntax/Parse.fs
@@ -361,3 +361,24 @@ let parseFile path =
         let! text = File.ReadAllTextAsync(path) |> Async.AwaitTask
         return readProgram path text
     }
+
+// -- File Collections ---------------------------------------------------------
+
+/// A parsed collection of program files, ready for the binder.
+type FileCollection = SyntaxRoot<Program> list
+
+module FileCollection =
+
+    /// Build a collection directly from already-parsed roots.
+    let ofRoots (roots: SyntaxRoot<Program> list) : FileCollection = roots
+
+    /// Parse each path on disk, accumulating diagnostics.
+    ///
+    /// Returns a `ParseResult` whose `Root` is the list of successfully-parsed
+    /// roots.  Any parse diagnostics from individual files are merged together.
+    let ofPaths (paths: string list) : ParseResult<FileCollection> =
+        paths
+        |> Seq.map (fun path ->
+            let contents = File.ReadAllText path
+            readProgram path contents)
+        |> ParseResult.fold (fun acc r -> acc @ [ r ]) []

--- a/src/Feersum.CompilerServices/Text.fs
+++ b/src/Feersum.CompilerServices/Text.fs
@@ -44,9 +44,7 @@ type public TextLocation =
         | Missing -> TextPoint.FromParts("missing", 0, 0)
 
 /// A document — owns path and line-start offsets for offset → line/col resolution.
-type public TextDocument =
-    { Path: string
-      LineStarts: int list }
+type public TextDocument = { Path: string; LineStarts: int list }
 
 module public TextDocument =
 

--- a/src/Feersum.CompilerServices/Text.fs
+++ b/src/Feersum.CompilerServices/Text.fs
@@ -43,19 +43,9 @@ type public TextLocation =
         | Point p -> p
         | Missing -> TextPoint.FromParts("missing", 0, 0)
 
-/// Opaque identifier for a source document.
-///
-/// `Doc i` indexes into the `SourceRegistry` that issued the ID.
-/// `Synthetic` marks compiler-generated nodes that have no source origin.
-[<RequireQualifiedAccess>]
-type public DocId =
-    | Doc of int
-    | Synthetic
-
 /// A document — owns path and line-start offsets for offset → line/col resolution.
 type public TextDocument =
-    { Id: DocId
-      Path: string
+    { Path: string
       LineStarts: int list }
 
 module public TextDocument =
@@ -69,14 +59,7 @@ module public TextDocument =
     /// Create a document with a synthetic (no source) ID.
     /// Suitable for tests and compiler-generated syntax.
     let public fromParts path body =
-        { Id = DocId.Synthetic
-          Path = path
-          LineStarts = lineStarts body }
-
-    /// Internal: create a document with a specific DocId (used by SourceRegistry).
-    let internal fromPartsWithId id path body =
-        { Id = id
-          Path = path
+        { Path = path
           LineStarts = lineStarts body }
 
     /// Turn a character offset into a document into a human line column value.

--- a/src/Feersum/Repl.fs
+++ b/src/Feersum/Repl.fs
@@ -14,7 +14,7 @@ open Feersum.CompilerServices.Syntax.Parse
 /// Read a single line of user input and parse it into a
 /// syntax tree. If the input can't be parsed then read
 /// again.
-let rec private read () : CompileInput =
+let rec private read stepIndex : CompileInput =
     let rec readWithState prompt previous =
         let line = ReadLine.Read prompt
 
@@ -29,15 +29,15 @@ let rec private read () : CompileInput =
             if line = "" && source.EndsWith("\n\n") then
                 Error parsed.Diagnostics
             else
-                readWithState "+> " (Some source)
+                readWithState $"+ {stepIndex}> " (Some source)
         else
             CompileInput.Script parsed.Root |> Ok
 
-    match readWithState "§> " None with
+    match readWithState $"§ {stepIndex}> " None with
     | Ok input -> input
     | Error diagnostics ->
         diagnostics |> dumpDiagnostics
-        read ()
+        read stepIndex
 
 /// Print an object out to the console. Used to serialise the external
 /// representation form an eval
@@ -62,7 +62,7 @@ let runRepl () =
     let rec loop ctx =
         let nextCtx =
             try
-                let result, next = evalInContext ctx (read ())
+                let result, next = evalInContext ctx (read ctx.StepIndex)
 
                 match result with
                 | Ok value -> print value

--- a/src/Feersum/Repl.fs
+++ b/src/Feersum/Repl.fs
@@ -54,7 +54,10 @@ let runRepl () =
     ReadLine.HistoryEnabled <- true
     printVersion ()
 
-    let options = { defaultScriptOptions with References = coreReferences }
+    let options =
+        { defaultScriptOptions with
+            References = coreReferences }
+
     let mutable state: Compilation option = None
 
     let rec loop () =

--- a/src/Feersum/Repl.fs
+++ b/src/Feersum/Repl.fs
@@ -54,19 +54,25 @@ let runRepl () =
     ReadLine.HistoryEnabled <- true
     printVersion ()
 
-    use ctx =
+    use initCtx =
         EvalContext.create
             { defaultScriptOptions with
                 References = coreReferences }
 
-    let rec loop () =
-        try
-            match evalInContext ctx (read ()) with
-            | Ok value -> print value
-            | Error diags -> dumpDiagnostics diags
-        with ex ->
-            eprintfn "Exception: %A" ex
+    let rec loop ctx =
+        let nextCtx =
+            try
+                let result, next = evalInContext ctx (read ())
 
-        loop ()
+                match result with
+                | Ok value -> print value
+                | Error diags -> dumpDiagnostics diags
 
-    loop ()
+                next
+            with ex ->
+                eprintfn "Exception: %A" ex
+                ctx
+
+        loop nextCtx
+
+    loop initCtx

--- a/src/Feersum/Repl.fs
+++ b/src/Feersum/Repl.fs
@@ -54,19 +54,14 @@ let runRepl () =
     ReadLine.HistoryEnabled <- true
     printVersion ()
 
-    let options =
-        { defaultScriptOptions with
-            References = coreReferences }
-
-    let mutable state: Compilation option = None
+    use ctx =
+        EvalContext.create
+            { defaultScriptOptions with
+                References = coreReferences }
 
     let rec loop () =
         try
-            let input = read ()
-            let result, next = evalWithPrev state options input
-            state <- next
-
-            match result with
+            match evalInContext ctx (read ()) with
             | Ok value -> print value
             | Error diags -> dumpDiagnostics diags
         with ex ->

--- a/src/Feersum/Repl.fs
+++ b/src/Feersum/Repl.fs
@@ -44,32 +44,31 @@ let rec private read () : CompileInput =
 let private print value =
     value |> cilExternalRepr |> printfn "}= %s"
 
-/// Read, Execute, Print Loop
+let coreReferences = [ typeof<LispProgram>.Assembly.Location ]
+
+/// Run the REPL, using the reflection-based evaluator.
 ///
-/// Repeatedly reads input and prints output
-let rec private repl evaluator =
+/// Each input is compiled as a script derived from the previous step so that
+/// top-level definitions and imports accumulate across lines.
+let runRepl () =
+    ReadLine.HistoryEnabled <- true
+    printVersion ()
+
+    let options = { defaultScriptOptions with References = coreReferences }
+    let mutable state: Compilation option = None
 
     let rec loop () =
         try
-            match read () |> evaluator with
-            | Result.Ok _ -> ()
-            | Result.Error diags -> dumpDiagnostics diags
+            let input = read ()
+            let result, next = evalWithPrev state options input
+            state <- next
+
+            match result with
+            | Ok value -> print value
+            | Error diags -> dumpDiagnostics diags
         with ex ->
             eprintfn "Exception: %A" ex
 
         loop ()
 
     loop ()
-
-let coreReferences = [ typeof<LispProgram>.Assembly.Location ]
-
-/// Run the REPL, using the reflection-based evaluator.
-let runRepl () =
-    ReadLine.HistoryEnabled <- true
-    printVersion ()
-
-    let options =
-        { defaultScriptOptions with
-            References = coreReferences }
-
-    evalWith options >> Result.map print |> repl

--- a/test/Feersum.Tests/BinderTests.fs
+++ b/test/Feersum.Tests/BinderTests.fs
@@ -21,9 +21,9 @@ let private expandRaw throwOnParseError (source: string) =
         failwithf "Parse error in '%s': %A" source prog.Diagnostics
 
     let coreLibs = Builtins.loadCoreSignatures TargetResolve.fromCurrentRuntime |> snd
+    let scope = Scope.ofLibraries coreLibs
 
-    let result =
-        Binder.bindProgram Environments.emptyStx Map.empty coreLibs Map.empty [ prog.Root ]
+    let result, _ = Binder.bindProgram scope [ prog.Root ]
 
     match result.Root.Body with
     | BoundExpr.Seq stmts -> stmts, result.Diagnostics

--- a/test/Feersum.Tests/LowerTests.fs
+++ b/test/Feersum.Tests/LowerTests.fs
@@ -15,10 +15,7 @@ let private lowerScheme source =
     if result |> Parse.ParseResult.hasErrors then
         failwithf "Parse error in '%s': %A" source result.Diagnostics
 
-    let env = Environments.empty
-    let initialScope, preloaded = Environments.intoParts env
-
-    let bound = Binder.bindProgram initialScope preloaded [] Map.empty [ result.Root ]
+    let bound, _ = Binder.bindProgram Scope.empty [ result.Root ]
     // if hasErrors bound.Diagnostics then
     //     failwithf "Bind error in '%s': %A" source bound.Diagnostics
 


### PR DESCRIPTION
Design doc 05 assumed a compiler-level Workspace wrapping SourceRegistry. The actual implementation removed SourceRegistry and made SyntaxRoot<'a> a self-contained value that carries its own TextDocument.

Add doc 06 which:
 - Collapses the three-layer model to two (parse → compilation)
 - Describes Workspace as an LSP-layer actor only (WorkspaceAgent)
 - Defines FileCollection as a plain list of SyntaxRoot<Program>
 - Specifies Scope as the explicit input/output of binder entry points, enabling ergonomic REPL chaining without re-compiling from scratch
 - Proposes SymbolTable (Definition, Reference, Exports, Imports) on BoundSyntaxTree to model the semantic content of a bound program, as the foundation for LSP hover, go-to-definition, and find-references